### PR TITLE
Fix calls to which and [

### DIFF
--- a/util/benchrun_daemon.sh
+++ b/util/benchrun_daemon.sh
@@ -282,11 +282,11 @@ function determine_process_invocation() {
     if [ $THIS_PLATFORM == 'Linux' ]
     then
         # ensure numa zone reclaims are off
-        if [ -x `which numactl` ]
+        if [ -x "`which numactl`" ]
         then
             MONGOD_START="numactl --physcpubind="$MONGOD_MASK" --interleave=all "
             BR_START="taskset -c "$BENCHRUN_MASK" "
-        elif [-x `which taskset` ]
+        elif [-x "`which taskset`" ]
         then
             MONGOD_START="taskset -c "$MONGOD_MASK" "
             BR_START="taskset -c "$BENCHRUN_MASK" "


### PR DESCRIPTION
The statement:

```
if [ -x `which somebin` ]; then
    echo hello
fi
```

Will almost always echo "hello". If `somebin` exists on the path, and is
executable, then "hello" will print. If `somebin` doesn't exist on the
path, `which` will return an empty string on `stdout`, which will be
inserted verbatim into the call to `[`, making the following:

```
if [ -x  ]; then
    echo hello
fi
```

Which, if you try it out in your shell, you will see still prints
"hello", since `[ -x ]` will always return true. Instead you should
quote those calls like this: `[ -x "`which somebin`" ]`, so that you
test against the following:

```
if [ -x "" ]; then
    echo hello
fi
```

When `somebin` doesn't exist. Currently the only scenario where your
checks for `numactl` and `taskset` will evaluate as false is when those
binaries exist on the path, but are not executable.
