### PR TITLE
Added tests for $where

### DIFF
--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -365,3 +365,20 @@ tests.push( { name: "Queries.FindProjectionDottedField.Indexed",
                     query: { 'x.y' : {"#RAND_INT_PLUS_THREAD": [0,100]}},
                     filter: { 'x.y' : 1, _id : 0 } }
               ] } );
+
+/*
+ * Setup: Insert 100 5mb documents into database
+ * Test: Do a table scan
+ */
+tests.push( { name: "Queries.LargeDocs",
+              tags: ['query','weekly','monthly'],
+              pre: function( collection ) {
+                  collection.drop();
+                  var bigString = new Array(1024*1024*5).toString();
+                  for ( var i = 0; i < 100; i++ ) {
+                      collection.insert( { x : bigString } );
+                  }
+              },
+              ops: [
+                  { op: "find", query: {} }
+              ] } );

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -9,7 +9,7 @@ if ( typeof(tests) != "object" ) {
  */
  function generateSimpleDocs(collection) {
     collection.drop();
-    for (var i = 0; i < 4800; i++) {
+    for (var i = 0; i < 1000; i++) {
         collection.insert({x: i});
     }
  }
@@ -83,8 +83,12 @@ tests.push({name: "Where.In.Where",
  */
  function generateArrayDocs(collection) {
     collection.drop();
-    for (var i = 0; i < 4800; i++) {
-        collection.insert({x: i});
+    for (var i = 0; i < 1000; i++) {
+        var numbers = [];
+        for (var j = 0; j < 10; j++) {
+          numbers.push(Math.floor(Math.random() * 101));
+        }
+        collection.insert({results: numbers});
     }
  }
 

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -154,7 +154,7 @@ tests.push({name: "Where.v1.Regex.Where",
             tags: ['query','where'],
             pre: generatePermutationsCollection,
             ops: [
-                {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); } } }
+                {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); }}}
             ]
             } );
 
@@ -206,7 +206,7 @@ tests.push({name: "Where.v1.SimpleNested.Where",
             tags: ['query', 'where'],
             pre: generateNestedCollection,
             ops: [
-                {op: "find", query: { '$where' : function() { return this.d.c.b.a === 1 } } }
+                {op:"find", query: {'$where': function() { return this.d.c.b.a === 1 }}}
             ]   
             } );
 
@@ -298,7 +298,7 @@ tests.push({name: "Where.v1.ComplexNested",
             tags: ['query','where'],
             pre: generateNestedCollection,
             ops: [
-                {op: "find", query: { '$where' : function() { return this.d.c.b.a === this.a.b.c.d } } }
+                {op: "find", query: {'$where': function() { return this.d.c.b.a === this.a.b.c.d }}}
             ]   
             } );
 
@@ -340,7 +340,7 @@ tests.push({name: "Where.v1.ReallyBigNestedComparison.QueryLanguage",
             tags: ['query','querylanguage'],
             pre: generateBigDeeplyNestedCollection,
             ops: [
-                {op: "find", query: { 'a.b.c.d' : 1 } }
+                {op: "find", query: { 'a.b.c.d' : 1 }}
             ]
             } );
 
@@ -352,6 +352,6 @@ tests.push({name: "Where.v1.ReallyBigNestedComparison.Where",
             tags: ['query','where'],
             pre: generateBigDeeplyNestedCollection,
             ops: [
-                {op: "find", query: { '$where': function() { return this.a.b.c.d == 1; } } } 
+                {op: "find", query: {'$where': function() { return this.a.b.c.d == 1; }}} 
             ]
             } );

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -5,149 +5,119 @@ if ( typeof(tests) != "object" ) {
 // Queries that can be written in query language and using $where
 
 /**
- * Setup: creates a collection with 4800 documents of the form { x : i }
- * Test: Finds { x : 1 } using query language
+ * Helper function to generate a collection with 4800 documents of the form { x : i }
  */
-tests.push( { name : "Where.v1.CompareToInt.QueryLanguage",
-              tags: ['query','querylanguage'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                      collection.insert( { x : i } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { x : 1 } }
-              ] } );
+ function generateSimpleDocs(collection) {
+    collection.drop();
+    for (var i = 0; i < 4800; i++) {
+        collection.insert({x: i});
+    }
+ }
 
 /**
- * Setup: creates a collection with 4800 documents of the form { x : i }
- * Test: Finds { x : 1 } using a $where query with ===
+ * Test: Finds {x: 1} using query language
  */
-tests.push( { name : "Where.v1.CompareToInt.Where.TripleEquals",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                      collection.insert( { x : i } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x === 1" } } 
-              ] } );
+tests.push({name: "Where.CompareToInt.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: generateSimpleDocs,
+            ops: [
+              {op: "find", query: {x : 1}}
+            ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form { x : i }
- * Test: Finds { x : 1 } using a $where query with ==
+ * Test: Finds {x: 1} using a $where query with === (type-safe equality)
  */
-tests.push( { name : "Where.v1.CompareToInt.Where.DoubleEquals",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                      collection.insert( { x : i } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x == 1" } } 
-              ] } );
+tests.push({name: "Where.CompareToInt.Where.TripleEquals",
+            tags: ['query','where'],
+            pre: generateSimpleDocs,
+            ops: [
+              {op: "find", query: {$where: "this.x === 1" }} 
+            ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds {x: 1} using a $where query with == (weak equality)
+ */
+tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
+            tags: ['query','where'],
+            pre: generateSimpleDocs,
+            ops: [
+              {op: "find", query: {$where: "this.x == 1" }} 
+            ]});
+
+/**
  * Test: Finds all documents with x between 1 and 6 using $in 
  */
-tests.push( { name : "Where.v1.In.QueryLanguage",
-              tags: ['query','querylanguage'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                      collection.insert( { x : i } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { x : { $in : [1, 2, 3, 4, 5, 6] } } } 
-              ] } );
+tests.push({name: "Where.In.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: generateSimpleDocs,
+            ops: [
+              {op: "find", query: {x: {$in: [1, 2, 3, 4, 5, 6]}}} 
+            ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form { x : i }
  * Test: Finds all documents with x between 1 and 6 using a $where query
  */
-tests.push( { name : "Where.v1.In.Where",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                      collection.insert( { x : i } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : function() {
-                    for (var j = 1; j <= 6; j++) {
-                      if (this.x == j) {
-                        return true;
-                      }
-                    }
-                    return false;
-                  } } }
-              ] } );
-
-/**
- * Setup: creates a collection with 4800 documents containing arrays of 10 
- * random numbers between 0 and 100
- * Test: Finds all documents with x containing y such that 80 <= y < 85 
- * using $elemMatch
- */
-tests.push( { name : "Where.v1.ElemMatch.QueryLanguage",
-              tags: ['query','querylanguage'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                    var numbers = [];
-                    for (var j = 0; j < 10; j++) {
-                      numbers.push(Math.floor(Math.random() * 101));
-                    }
-                    collection.insert( { results : numbers } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { results : { $elemMatch : { $gte : 80, $lt : 85 } } } }
-              ] } );
-
-/**
- * Setup: creates a collection with 4800 documents containing arrays of 10 
- * random numbers between 0 and 100
- * Test: Finds all documents with x containing y such that 80 <= y < 85 
- * using a $where query
- */
-tests.push( { name : "Where.v1.ElemMatch.Where",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 4800; i++ ) {
-                    var numbers = [];
-                    for (var j = 0; j < 10; j++) {
-                      numbers.push(Math.floor(Math.random() * 101));
-                    }
-                    collection.insert( { results : numbers } );
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : function() {
-                  for (result in this.results) {
-                    if ((this.results[result] >= 80) && (this.results[result] < 85)) {
+tests.push({name: "Where.In.Where",
+            tags: ['query','where'],
+            pre: generateSimpleDocs,
+            ops: [
+              {op: "find", query: {$where: function() {
+                  for (var j = 1; j <= 6; j++) {
+                    if (this.x == j) {
                       return true;
                     }
                   }
                   return false;
-                } } }
-              ] } );
+                }
+              }}
+            ]});
+
+/**
+ * Helper function to generate a collection with 4800 documents containing arrays of 10 
+ * random numbers between 0 and 100
+ */
+ function generateArrayDocs(collection) {
+    collection.drop();
+    for (var i = 0; i < 4800; i++) {
+        collection.insert({x: i});
+    }
+ }
+
+/**
+ * Test: Finds all documents with x containing y such that 80 <= y < 85 
+ * using $elemMatch
+ */
+tests.push({name: "Where.ElemMatch.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: generateArrayDocs,
+            ops: [
+              {op: "find", query: {results: {$elemMatch: {$gte: 80, $lt: 85 }}}}
+            ]});
+
+/**
+ * Test: Finds all documents with x containing y such that 80 <= y < 85 
+ * using a $where query
+ */
+tests.push({name: "Where.ElemMatch.Where",
+            tags: ['query','where'],
+            pre: generateArrayDocs,
+            ops: [
+              {op: "find", query: {$where : function() {
+                for (result in this.results) {
+                  if ((this.results[result] >= 80) && (this.results[result] < 85)) {
+                    return true;
+                  }
+                }
+                return false;
+              }}}
+            ]});
 
 /*
  * Helper function to generate permutations for Regex queries
  */
 function generatePermutations() {
     var strings = [];
-    for ( var i = 0; i < 26; i++ ) {
+    for (var i = 0; i < 26; i++) {
         strings.push(String.fromCharCode(95+i));
     }
     var collection = [];
@@ -155,7 +125,7 @@ function generatePermutations() {
         for (var j = 0; j < 26; j++ ) {
             for (var k = 0; k < 26; k++ ) {
                 for (var l = 0; l < 26; l++ ) {
-                    collection.push( { x : strings[i]+strings[j]+strings[k]+strings[l] } ); 
+                    collection.push( { x : strings[i]+strings[j]+strings[k]+strings[l]}); 
                 }
             }
         }
@@ -167,7 +137,7 @@ function generatePermutations() {
  * Setup: Create collection with documents containing 4 character alphabetic permutations
  * Test: Find document based on Regex Query
  */
-tests.push( { name : "Where.v1.Regex.QueryLanguage",
+tests.push({name: "Where.v1.Regex.QueryLanguage",
             tags: ['query','querylanguage'],
             pre: function(collection) {
                 collection.drop();
@@ -175,7 +145,7 @@ tests.push( { name : "Where.v1.Regex.QueryLanguage",
                 collection.insert(coll)
             },
             ops: [
-                { op : "find", query : { x : /^aa/ } }
+                {op: "find", query: { x : /^aa/ } }
             ]
             } );
 
@@ -183,7 +153,7 @@ tests.push( { name : "Where.v1.Regex.QueryLanguage",
  * Setup: Create collection with documents containing 4 character alphabetic permutations
  * Test: Find document based on Regex $where
  */
-tests.push( { name : "Where.v1.Regex.Where",
+tests.push({name: "Where.v1.Regex.Where",
             tags: ['query','where'],
             pre: function(collection) {
                 collection.drop();
@@ -191,7 +161,7 @@ tests.push( { name : "Where.v1.Regex.Where",
                 collection.insert(coll)
             },
             ops: [
-                { op : "find", query : { '$where' : function() { return /^aa/.test(this.x); } } }
+                {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); } } }
             ]
             } );
 
@@ -226,7 +196,7 @@ function generateNestedCollection() {
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of deeply nested field using Query Language
  */
-tests.push( { name : "Where.v1.SimpleNested.QueryLanguage",
+tests.push({name: "Where.v1.SimpleNested.QueryLanguage",
             tags: ['query','querylanguage'],
             pre: function(collection) {
                 collection.drop();
@@ -234,7 +204,7 @@ tests.push( { name : "Where.v1.SimpleNested.QueryLanguage",
                 collection.insert(coll);
             },
             ops: [
-                { op : "find", query : { 'd.c.b.a' : 1 } }
+                {op: "find", query: { 'd.c.b.a' : 1 } }
             ]
             } );
 
@@ -242,7 +212,7 @@ tests.push( { name : "Where.v1.SimpleNested.QueryLanguage",
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of deeply nested field using $where
  */
-tests.push( { name : "Where.v1.SimpleNested.Where",
+tests.push({name: "Where.v1.SimpleNested.Where",
             tags: ['query', 'where'],
             pre: function(collection) {
                 collection.drop();
@@ -250,125 +220,95 @@ tests.push( { name : "Where.v1.SimpleNested.Where",
                 collection.insert(coll);
             },
             ops: [
-                { op : "find", query : { '$where' : function() { return this.d.c.b.a === 1 } } }
+                {op: "find", query: { '$where' : function() { return this.d.c.b.a === 1 } } }
             ]   
             } );
 
 // Queries that require the use of $where
 
 /**
+ * Helper function to generate a collection with 40,000 documents of the form { x : i, y : j}
+ */
+ function generateTupleDocs(collection) {
+    collection.drop();
+    for (var i = 0; i < 200; i++) {
+      for (var j = 0; j < 200; j++) {
+        collection.insert({x: i, y: j});
+      }
+    }
+ }
+
+/**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x == y
  */
-tests.push( { name : "Where.v1.CompareFields.Equals",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x == this.y" } } 
-              ] } );
+tests.push({name: "Where.CompareFields.Equals",
+            tags: ['query','where'],
+            pre: generateTupleDocs,
+            ops: [
+              {op: "find", query: {$where: function() { return this.x == this.y } } } 
+            ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x > y
  */
-tests.push( { name : "Where.v1.CompareFields.Gt",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x > this.y" } } 
-              ] } );
+tests.push({name: "Where.CompareFields.Gt",
+            tags: ['query','where'],
+            pre: generateTupleDocs,
+            ops: [
+              {op: "find", query: {$where: function() {return this.x > this.y}}} 
+            ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x >= y
  */
-tests.push( { name : "Where.v1.CompareFields.Gte",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x >= this.y" } } 
-              ] } );
+tests.push({name: "Where.CompareFields.Gte",
+            tags: ['query','where'],
+            pre: generateTupleDocs,
+            ops: [
+              {op: "find", query: {$where: function() {return this.x >= this.y}}} 
+            ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x < y
  */
-tests.push( { name : "Where.v1.CompareFields.Lt",
-              tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x < this.y" } } 
-              ] } );
+tests.push({name: "Where.CompareFields.Lt",
+            tags: ['query','where'],
+            pre: generateTupleDocs,
+            ops: [
+              {op: "find", query: {$where: function() {return this.x < this.y}}}
+            ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x <= y
  */
-tests.push( { name : "Where.v1.CompareFields.Lte",
+tests.push({name: "Where.CompareFields.Lte",
               tags: ['query','where'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $where : "this.x <= this.y" } } 
-              ] } );
+              pre: generateTupleDocs,
+              ops: [
+                {op: "find", query: {$where: function() {return this.x <= this.y}}}
+              ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
  * Test: Finds all documents where x == 2 or y == 3 
  */
-tests.push( { name : "Where.v1.Mixed",
-              tags: ['query','where','querylanguage'],
-              pre: function( collection ) {
-                  collection.drop();
-                  for ( var i = 0; i < 200; i++ ) {
-                    for ( var j = 0; j < 200; j++ ) {
-                      collection.insert( { x : i, y : j } );
-                    }
-                  }
-              },
-              ops : [
-                { op : "find", query : { $or : [ { x : 2 }, { $where : function() { return (this.y == 3); } } ] } } 
-              ] } );
+tests.push({name: "Where.Mixed",
+            tags: ['query','where','querylanguage'],
+            pre: generateTupleDocs,
+            ops: [
+              {op: "find", query: {$or : [{x: 2}, {$where: function() {return (this.y == 3);}}]}} 
+            ]});
 
 /*
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of two deeply nested fields on the same document using $where
  */
-tests.push( { name : "Where.v1.ComplexNested",
+tests.push({name: "Where.v1.ComplexNested",
             tags: ['query','where'],
             pre: function(collection) {
                 collection.drop();
@@ -376,7 +316,7 @@ tests.push( { name : "Where.v1.ComplexNested",
                 collection.insert(coll);
             },
             ops: [
-                { op : "find", query : { '$where' : function() { return this.d.c.b.a === this.a.b.c.d } } }
+                {op: "find", query: { '$where' : function() { return this.d.c.b.a === this.a.b.c.d } } }
             ]   
             } );
 
@@ -413,7 +353,7 @@ function generateBigDeeplyNestedCollection() {
  * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
  * Test: Find document through match of a deeply nested field using query language
  */
-tests.push( { name : "Where.v1.ReallyBigNestedComparison.QueryLanguage",
+tests.push({name: "Where.v1.ReallyBigNestedComparison.QueryLanguage",
             tags: ['query','querylanguage'],
             pre: function(collection) {
                 collection.drop();
@@ -421,7 +361,7 @@ tests.push( { name : "Where.v1.ReallyBigNestedComparison.QueryLanguage",
                 collection.insert(coll);
             },
             ops: [
-                { op : "find", query : { 'a.b.c.d' : 1 } }
+                {op: "find", query: { 'a.b.c.d' : 1 } }
             ]
             } );
 
@@ -429,7 +369,7 @@ tests.push( { name : "Where.v1.ReallyBigNestedComparison.QueryLanguage",
  * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
  * Test: Find document through match of a deeply nested field using $where 
  */
-tests.push( { name : "Where.v1.ReallyBigNestedComparison.Where",
+tests.push({name: "Where.v1.ReallyBigNestedComparison.Where",
             tags: ['query','where'],
             pre: function(collection) {
                 collection.drop();
@@ -437,6 +377,6 @@ tests.push( { name : "Where.v1.ReallyBigNestedComparison.Where",
                 collection.insert(coll);
             },
             ops: [
-                { op : "find", query : { '$where': function() { return this.a.b.c.d == 1; } } } 
+                {op: "find", query: { '$where': function() { return this.a.b.c.d == 1; } } } 
             ]
             } );

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -5,7 +5,7 @@ if ( typeof(tests) != "object" ) {
 // Queries that can be written in query language and using $where
 
 /**
- * Helper function to generate a collection with 4800 documents of the form { x : i }
+ * Helper function to generate a collection with 4800 documents of the form {x : i}
  */
  function generateSimpleDocs(collection) {
     collection.drop();
@@ -15,6 +15,7 @@ if ( typeof(tests) != "object" ) {
  }
 
 /**
+ * Setup: creates a collection with 4800 documents of the form {x : i}
  * Test: Finds {x: 1} using query language
  */
 tests.push({name: "Where.CompareToInt.QueryLanguage",
@@ -25,6 +26,7 @@ tests.push({name: "Where.CompareToInt.QueryLanguage",
             ]});
 
 /**
+ * Setup: creates a collection with 4800 documents of the form {x : i}
  * Test: Finds {x: 1} using a $where query with === (type-safe equality)
  */
 tests.push({name: "Where.CompareToInt.Where.TripleEquals",
@@ -35,6 +37,7 @@ tests.push({name: "Where.CompareToInt.Where.TripleEquals",
             ]});
 
 /**
+ * Setup: creates a collection with 4800 documents of the form {x : i}
  * Test: Finds {x: 1} using a $where query with == (weak equality)
  */
 tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
@@ -45,6 +48,7 @@ tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
             ]});
 
 /**
+ * Setup: creates a collection with 4800 documents of the form {x : i}
  * Test: Finds all documents with x between 1 and 6 using $in 
  */
 tests.push({name: "Where.In.QueryLanguage",
@@ -55,6 +59,7 @@ tests.push({name: "Where.In.QueryLanguage",
             ]});
 
 /**
+ * Setup: creates a collection with 4800 documents of the form {x : i}
  * Test: Finds all documents with x between 1 and 6 using a $where query
  */
 tests.push({name: "Where.In.Where",
@@ -84,6 +89,8 @@ tests.push({name: "Where.In.Where",
  }
 
 /**
+ * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * random numbers between 0 and 100
  * Test: Finds all documents with x containing y such that 80 <= y < 85 
  * using $elemMatch
  */
@@ -95,6 +102,8 @@ tests.push({name: "Where.ElemMatch.QueryLanguage",
             ]});
 
 /**
+ * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * random numbers between 0 and 100
  * Test: Finds all documents with x containing y such that 80 <= y < 85 
  * using a $where query
  */
@@ -213,7 +222,7 @@ tests.push({name: "Where.v1.SimpleNested.Where",
 // Queries that require the use of $where
 
 /**
- * Helper function to generate a collection with 40,000 documents of the form { x : i, y : j}
+ * Helper function to generate a collection with 40,000 documents of the form {x: i, y: j}
  */
  function generateTupleDocs(collection) {
     collection.drop();
@@ -225,7 +234,7 @@ tests.push({name: "Where.v1.SimpleNested.Where",
  }
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x == y
  */
 tests.push({name: "Where.CompareFields.Equals",
@@ -236,7 +245,7 @@ tests.push({name: "Where.CompareFields.Equals",
             ]});
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x > y
  */
 tests.push({name: "Where.CompareFields.Gt",
@@ -247,7 +256,7 @@ tests.push({name: "Where.CompareFields.Gt",
             ]});
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x >= y
  */
 tests.push({name: "Where.CompareFields.Gte",
@@ -258,7 +267,7 @@ tests.push({name: "Where.CompareFields.Gte",
             ]});
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x < y
  */
 tests.push({name: "Where.CompareFields.Lt",
@@ -269,7 +278,7 @@ tests.push({name: "Where.CompareFields.Lt",
             ]});
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x <= y
  */
 tests.push({name: "Where.CompareFields.Lte",
@@ -280,7 +289,7 @@ tests.push({name: "Where.CompareFields.Lte",
               ]});
 
 /**
- * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
  * Test: Finds all documents where x == 2 or y == 3 
  */
 tests.push({name: "Where.Mixed",

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -67,7 +67,7 @@ function arrayGenerator() {
 function permutationGenerator() {
     var strings = [];
     for (var i = 0; i < 26; i++) {
-        strings.push(String.fromCharCode(95+i));
+        strings.push(String.fromCharCode(97+i));
     }
     var i = 0;
     var j = 0;
@@ -97,7 +97,7 @@ function permutationGenerator() {
 function nestedGenerator(big) {
     var strings = [];
     for (var i = 0; i < 26; i++) {
-        strings.push(String.fromCharCode(95+i));
+        strings.push(String.fromCharCode(97+i));
     }
     var i = 0;
     var levelSize = big ? 26 : 13;
@@ -157,24 +157,6 @@ tests.push({name: "Where.CompareToInt.Where.TripleEquals",
               {op: "find", query: {$where: function() {return this.x === 1;}}} 
             ]});
 
-/**
- * Setup: creates a collection with documents of the form {x : i}
- * Test: Finds all documents with x between 1 and 6 using a $where query
- */
-tests.push({name: "Where.In.Where",
-            tags: ['query','where'],
-            pre: generateDocs(1000, increasingXGenerator()),
-            ops: [
-              {op: "find", query: {$where: function() {
-                  for (var j = 1; j <= 6; j++) {
-                    if (this.x == j) {
-                      return true;
-                    }
-                  }
-                  return false;
-                }
-              }}
-            ]});
 
 /**
  * Setup: creates a collection with documents of the form {x : i}
@@ -187,63 +169,6 @@ tests.push({name: "Where.In.QueryLanguage",
               {op: "find", query: {x: {$in: [1, 2, 3, 4, 5, 6]}}} 
             ]});
 
-/**
- * Setup: creates a collection with documents containing arrays of 10 
- * random numbers between 0 and 100
- * Test: Finds all documents with x containing y such that 80 <= y < 85 
- * using a $where query
- */
-tests.push({name: "Where.ElemMatch.Where",
-            tags: ['query','where'],
-            pre: generateDocs(1000, arrayGenerator),
-            ops: [
-              {op: "find", query: {$where : function() {
-                for (result in this.results) {
-                  if ((this.results[result] >= 80) && (this.results[result] < 85)) {
-                    return true;
-                  }
-                }
-                return false;
-              }}}
-            ]});
-
-/**
- * Setup: creates a collection with documents containing arrays of 10 
- * random numbers between 0 and 100
- * Test: Finds all documents with x containing y such that 80 <= y < 85 
- * using $elemMatch
- */
-tests.push({name: "Where.ElemMatch.QueryLanguage",
-            tags: ['query','compare'],
-            pre: generateDocs(1000, arrayGenerator),
-            ops: [
-              {op: "find", query: {results: {$elemMatch: {$gte: 80, $lt: 85 }}}}
-            ]});
-
-/*
- * Setup: Create collection with documents containing 4 character alphabetic permutations
- * Test: Find document based on Regex $where
- */
-tests.push({name: "Where.Regex.Where",
-            tags: ['query','where'],
-            pre: generateDocs(Math.pow(26, 4), permutationGenerator()),
-            ops: [
-              {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); }}}
-            ]
-            } );
-
-/*
- * Setup: Create collection with documents containing 4 character alphabetic permutations
- * Test: Find document based on Regex Query
- */
-tests.push({name: "Where.Regex.QueryLanguage",
-            tags: ['query','compare'],
-            pre: generateDocs(Math.pow(26, 4), permutationGenerator()),
-            ops: [
-              {op: "find", query: { x : /^aa/ } }
-            ]
-            } );
-
 /*
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of deeply nested field using $where
@@ -252,7 +177,7 @@ tests.push({name: "Where.SimpleNested.Where",
             tags: ['query', 'where'],
             pre: generateDocs(13, nestedGenerator(false)),
             ops: [
-              {op:"find", query: {'$where': function() { return this.d.c.b.a === 1 }}}
+              {op:"find", query: {'$where': function() { return this.d.c.b.a === 1; }}}
             ]   
             } );
 
@@ -278,7 +203,7 @@ tests.push({name: "Where.CompareFields.Equals",
             tags: ['query','where'],
             pre: generateDocs(1000, increasingXGenerator()),
             ops: [
-              {op: "find", query: {$where: function() {return this.x == this.y}}} 
+              {op: "find", query: {$where: function() {return this.x == this.y; }}} 
             ]});
 
 /**
@@ -289,7 +214,7 @@ tests.push({name: "Where.CompareFields.Gt",
             tags: ['query','where'],
             pre: generateDocs(200, tupleGenerator(200)),
             ops: [
-              {op: "find", query: {$where: function() {return this.x > this.y}}} 
+              {op: "find", query: {$where: function() {return this.x > this.y; }}} 
             ]});
 
 /**
@@ -300,7 +225,7 @@ tests.push({name: "Where.CompareFields.Gte",
             tags: ['query','where'],
             pre: generateDocs(200, tupleGenerator(200)),
             ops: [
-              {op: "find", query: {$where: function() {return this.x >= this.y}}} 
+              {op: "find", query: {$where: function() {return this.x >= this.y; }}} 
             ]});
 
 /**
@@ -311,7 +236,7 @@ tests.push({name: "Where.CompareFields.Lt",
             tags: ['query','where'],
             pre: generateDocs(200, tupleGenerator(200)),
             ops: [
-              {op: "find", query: {$where: function() {return this.x < this.y}}}
+              {op: "find", query: {$where: function() {return this.x < this.y; }}}
             ]});
 
 /**
@@ -322,7 +247,7 @@ tests.push({name: "Where.CompareFields.Lte",
             tags: ['query','where'],
             pre: generateDocs(200, tupleGenerator(200)),
             ops: [
-              {op: "find", query: {$where: function() {return this.x <= this.y}}}
+              {op: "find", query: {$where: function() {return this.x <= this.y; }}}
             ]});
 
 /**
@@ -344,7 +269,7 @@ tests.push({name: "Where.ComplexNested",
             tags: ['query','where'],
             pre: generateDocs(10, nestedGenerator(true)),
             ops: [
-              {op: "find", query: {'$where': function() { return this.d.c.b.a === this.a.b.c.d }}}
+              {op: "find", query: {'$where': function() { return this.d.c.b.a === this.a.b.c.d; }}}
             ]   
             } );
 
@@ -372,4 +297,4 @@ tests.push({name: "Where.ReallyBigNestedComparison.QueryLanguage",
             ops: [
               {op: "find", query: { 'a.b.c.d' : 1 }}
             ]
-            } );
+            });

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -1,0 +1,442 @@
+if ( typeof(tests) != "object" ) {
+    tests = [];
+}
+
+// Queries that can be written in query language and using $where
+
+/**
+ * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds { x : 1 } using query language
+ */
+tests.push( { name : "Where.v1.CompareToInt.QueryLanguage",
+              tags: ['query','querylanguage'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                      collection.insert( { x : i } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { x : 1 } }
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds { x : 1 } using a $where query with ===
+ */
+tests.push( { name : "Where.v1.CompareToInt.Where.TripleEquals",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                      collection.insert( { x : i } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x === 1" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds { x : 1 } using a $where query with ==
+ */
+tests.push( { name : "Where.v1.CompareToInt.Where.DoubleEquals",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                      collection.insert( { x : i } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x == 1" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds all documents with x between 1 and 6 using $in 
+ */
+tests.push( { name : "Where.v1.In.QueryLanguage",
+              tags: ['query','querylanguage'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                      collection.insert( { x : i } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { x : { $in : [1, 2, 3, 4, 5, 6] } } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents of the form { x : i }
+ * Test: Finds all documents with x between 1 and 6 using a $where query
+ */
+tests.push( { name : "Where.v1.In.Where",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                      collection.insert( { x : i } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : function() {
+                    for (var j = 1; j <= 6; j++) {
+                      if (this.x == j) {
+                        return true;
+                      }
+                    }
+                    return false;
+                  } } }
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * random numbers between 0 and 100
+ * Test: Finds all documents with x containing y such that 80 <= y < 85 
+ * using $elemMatch
+ */
+tests.push( { name : "Where.v1.ElemMatch.QueryLanguage",
+              tags: ['query','querylanguage'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                    var numbers = [];
+                    for (var j = 0; j < 10; j++) {
+                      numbers.push(Math.floor(Math.random() * 101));
+                    }
+                    collection.insert( { results : numbers } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { results : { $elemMatch : { $gte : 80, $lt : 85 } } } }
+              ] } );
+
+/**
+ * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * random numbers between 0 and 100
+ * Test: Finds all documents with x containing y such that 80 <= y < 85 
+ * using a $where query
+ */
+tests.push( { name : "Where.v1.ElemMatch.Where",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 4800; i++ ) {
+                    var numbers = [];
+                    for (var j = 0; j < 10; j++) {
+                      numbers.push(Math.floor(Math.random() * 101));
+                    }
+                    collection.insert( { results : numbers } );
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : function() {
+                  for (result in this.results) {
+                    if ((this.results[result] >= 80) && (this.results[result] < 85)) {
+                      return true;
+                    }
+                  }
+                  return false;
+                } } }
+              ] } );
+
+/*
+ * Helper function to generate permutations for Regex queries
+ */
+function generatePermutations() {
+    var strings = [];
+    for ( var i = 0; i < 26; i++ ) {
+        strings.push(String.fromCharCode(95+i));
+    }
+    var collection = [];
+    for ( var i = 0; i < 26; i++ ) {
+        for (var j = 0; j < 26; j++ ) {
+            for (var k = 0; k < 26; k++ ) {
+                for (var l = 0; l < 26; l++ ) {
+                    collection.push( { x : strings[i]+strings[j]+strings[k]+strings[l] } ); 
+                }
+            }
+        }
+    }
+    return collection;
+}
+
+/*
+ * Setup: Create collection with documents containing 4 character alphabetic permutations
+ * Test: Find document based on Regex Query
+ */
+tests.push( { name : "Where.v1.Regex.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generatePermutations();
+                collection.insert(coll)
+            },
+            ops: [
+                { op : "find", query : { x : /^aa/ } }
+            ]
+            } );
+
+/*
+ * Setup: Create collection with documents containing 4 character alphabetic permutations
+ * Test: Find document based on Regex $where
+ */
+tests.push( { name : "Where.v1.Regex.Where",
+            tags: ['query','where'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generatePermutations();
+                collection.insert(coll)
+            },
+            ops: [
+                { op : "find", query : { '$where' : function() { return /^aa/.test(this.x); } } }
+            ]
+            } );
+
+/*
+ * Helper function to generate collection of deeply nested documents
+ */
+function generateNestedCollection() {
+    var strings = [];
+    for ( var i = 0; i < 26; i++ ) {
+        strings.push(String.fromCharCode(95+i));
+    }
+    var collection = [];
+    for ( var i = 0; i < 13; i++ ) {
+        collection[i] = {};
+        for (var j = 0; j < 13; j++) {
+            collection[i][strings[j]] = {};
+            for ( var k = 0; k < 13; k++) {
+                collection[i][strings[j]][strings[k]] = {};
+                for ( var l = 0; l < 13; l++) {
+                    collection[i][strings[j]][strings[k]][strings[l]] = {};
+                    for ( var m = 0; m < 13; m++) {
+                        collection[i][strings[j]][strings[k]][strings[l]][strings[m]] = i + j + k + l + m;
+                    }
+                }
+            }
+        }
+    }
+    return collection
+}
+
+/*
+ * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
+ * Test: Find document through match of deeply nested field using Query Language
+ */
+tests.push( { name : "Where.v1.SimpleNested.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generateNestedCollection();
+                collection.insert(coll);
+            },
+            ops: [
+                { op : "find", query : { 'd.c.b.a' : 1 } }
+            ]
+            } );
+
+/*
+ * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
+ * Test: Find document through match of deeply nested field using $where
+ */
+tests.push( { name : "Where.v1.SimpleNested.Where",
+            tags: ['query', 'where'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generateNestedCollection();
+                collection.insert(coll);
+            },
+            ops: [
+                { op : "find", query : { '$where' : function() { return this.d.c.b.a === 1 } } }
+            ]   
+            } );
+
+// Queries that require the use of $where
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x == y
+ */
+tests.push( { name : "Where.v1.CompareFields.Equals",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x == this.y" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x > y
+ */
+tests.push( { name : "Where.v1.CompareFields.Gt",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x > this.y" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x >= y
+ */
+tests.push( { name : "Where.v1.CompareFields.Gte",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x >= this.y" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x < y
+ */
+tests.push( { name : "Where.v1.CompareFields.Lt",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x < this.y" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x <= y
+ */
+tests.push( { name : "Where.v1.CompareFields.Lte",
+              tags: ['query','where'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $where : "this.x <= this.y" } } 
+              ] } );
+
+/**
+ * Setup: creates a collection with 40,000 documents of the form { x : i, y : j}
+ * Test: Finds all documents where x == 2 or y == 3 
+ */
+tests.push( { name : "Where.v1.Mixed",
+              tags: ['query','where','querylanguage'],
+              pre: function( collection ) {
+                  collection.drop();
+                  for ( var i = 0; i < 200; i++ ) {
+                    for ( var j = 0; j < 200; j++ ) {
+                      collection.insert( { x : i, y : j } );
+                    }
+                  }
+              },
+              ops : [
+                { op : "find", query : { $or : [ { x : 2 }, { $where : function() { return (this.y == 3); } } ] } } 
+              ] } );
+
+/*
+ * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
+ * Test: Find document through match of two deeply nested fields on the same document using $where
+ */
+tests.push( { name : "Where.v1.ComplexNested",
+            tags: ['query','where'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generateNestedCollection();
+                collection.insert(coll);
+            },
+            ops: [
+                { op : "find", query : { '$where' : function() { return this.d.c.b.a === this.a.b.c.d } } }
+            ]   
+            } );
+
+// Queries to experiment with document size
+
+/*
+ * Helper function to generate collection with large deeply nested documents
+ */
+function generateBigDeeplyNestedCollection() {
+    var strings = [];
+    for ( var i = 0; i < 26; i++ ) {
+        strings.push(String.fromCharCode(95+i));
+    }
+    var collection = [];
+    for ( var i = 0; i < 10; i++ ) {
+        collection[i] = {};
+        for (var j = 0; j < 26; j++) {
+            collection[i][strings[j]] = {};
+            for ( var k = 0; k < 26; k++) {
+                collection[i][strings[j]][strings[k]] = {};
+                for ( var l = 0; l < 26; l++) {
+                    collection[i][strings[j]][strings[k]][strings[l]] = {};
+                    for ( var m = 0; m < 26; m++) {
+                        collection[i][strings[j]][strings[k]][strings[l]][strings[m]] = i + j + k + l + m;
+                    }
+                }
+            }
+        }
+    }
+    return collection;
+}
+
+/*
+ * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
+ * Test: Find document through match of a deeply nested field using query language
+ */
+tests.push( { name : "Where.v1.ReallyBigNestedComparison.QueryLanguage",
+            tags: ['query','querylanguage'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generateBigDeeplyNestedCollection();
+                collection.insert(coll);
+            },
+            ops: [
+                { op : "find", query : { 'a.b.c.d' : 1 } }
+            ]
+            } );
+
+/*
+ * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
+ * Test: Find document through match of a deeply nested field using $where 
+ */
+tests.push( { name : "Where.v1.ReallyBigNestedComparison.Where",
+            tags: ['query','where'],
+            pre: function(collection) {
+                collection.drop();
+                var coll = generateBigDeeplyNestedCollection();
+                collection.insert(coll);
+            },
+            ops: [
+                { op : "find", query : { '$where': function() { return this.a.b.c.d == 1; } } } 
+            ]
+            } );

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -2,69 +2,187 @@ if ( typeof(tests) != "object" ) {
     tests = [];
 }
 
-// Queries that can be written in query language and using $where
+// Document generation functions
 
 /**
- * Helper function to generate a collection with 4800 documents of the form {x : i}
+ * Helper function to generate documents in the collection using the 
+ * generator function to generate the documents
  */
- function generateSimpleDocs(collection) {
+ function generateDocs(collection, nDocs, generator) {
     collection.drop();
-    for (var i = 0; i < 1000; i++) {
-        collection.insert({x: i});
+    docs = [];
+    for (var i = 0; i < n; i++) {
+      docs.push(generator());
     }
+    collection.insert(docs);
  }
 
 /**
- * Setup: creates a collection with 4800 documents of the form {x : i}
+ * Generates simple docs with increasing x value
+ */
+function increasingXGenerator() {
+  var x = 0;
+  return function() {
+      var doc = { "x" : x};
+      x++;
+      return doc;
+  };
+}
+
+/**
+ * Generates a documents containing an array of 10 
+ * random numbers between 0 and 100
+ */
+ function arrayGenerator() {
+    var results = [];
+    for (var j = 0; j < 10; j++) {
+      results.push(Math.floor(Math.random() * 101));
+    }
+    return {"results": numbers};
+ }
+
+/**
+ * Generates documents of the form {x: i, y: j}
+ * with increasing values for x and y 
+ * y will cycle from 0 to numY.
+ */
+ function tupleGenerator(numY) {
+    var x = 0;
+    var y = 0;
+    return function() {
+      var doc = { "x" : x, "y": y};
+      if (y++ > maxYValue) {
+        y = 0;
+        x++;
+      }
+      return doc;
+    };
+ }
+
+/**
+ * Generates documents containing 4-letter strings
+ */
+function permutationGenerator() {
+    var strings = [];
+    for (var i = 0; i < 26; i++) {
+        strings.push(String.fromCharCode(95+i));
+    }
+    var i = 0;
+    var j = 0;
+    var k = 0;
+    var l = 0;
+    return function() {
+      var doc = {x: strings[i]+strings[j]+strings[k]+strings[l]};
+      if (++l > 25) {
+        l = 0;
+        if (++k > 25) {
+            k = 0;
+            if (++j > 25) {
+                j = 0;
+                if (++i > 25) {
+                    i = 0;
+                }
+            }
+        }
+      }
+      return doc;
+  };
+}
+
+/**
+ * Generates deeply nested documents
+ */
+function nestedGenerator(big) {
+    var strings = [];
+    for (var i = 0; i < 26; i++) {
+        strings.push(String.fromCharCode(95+i));
+    }
+    var i = 0;
+    var levelSize = big ? 26 : 13;
+    return function() {
+      doc = {};
+      for (var j = 0; j < levelSize; j++) {
+            collection[i][strings[j]] = {};
+            for (var k = 0; k < levelSize; k++) {
+                collection[i][strings[j]][strings[k]] = {};
+                for (var l = 0; l < levelSize; l++) {
+                    collection[i][strings[j]][strings[k]][strings[l]] = {};
+                    for (var m = 0; m < levelSize; m++) {
+                        collection[i][strings[j]][strings[k]][strings[l]][strings[m]] 
+                            = i + j + k + l + m;
+                    }
+                }
+            }
+        }
+      i++;
+      return doc;
+  };
+}
+
+
+// Queries that can be written in query language and using $where
+
+/**
+ * Setup: creates a collection with documents of the form {x : i}
  * Test: Finds {x: 1} using query language
  */
 tests.push({name: "Where.CompareToInt.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generateSimpleDocs,
+            pre: function(collection) {
+                generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
               {op: "find", query: {x : 1}}
             ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form {x : i}
+ * Setup: creates a collection with documents of the form {x : i}
  * Test: Finds {x: 1} using a $where query with === (type-safe equality)
  */
 tests.push({name: "Where.CompareToInt.Where.TripleEquals",
             tags: ['query','where'],
-            pre: generateSimpleDocs,
+            pre: function(collection) {
+                generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
-              {op: "find", query: {$where: "this.x === 1" }} 
+              {op: "find", query: {$where: function() {return this.x === 1;}}} 
             ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form {x : i}
+ * Setup: creates a collection with documents of the form {x : i}
  * Test: Finds {x: 1} using a $where query with == (weak equality)
  */
 tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
             tags: ['query','where'],
-            pre: generateSimpleDocs,
+            pre: function(collection) {
+                generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
-              {op: "find", query: {$where: "this.x == 1" }} 
+              {op: "find", query: {$where: function() {return this.x === 1;}}} 
             ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form {x : i}
+ * Setup: creates a collection with documents of the form {x : i}
  * Test: Finds all documents with x between 1 and 6 using $in 
  */
 tests.push({name: "Where.In.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generateSimpleDocs,
+            pre: function(collection) {
+                generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
               {op: "find", query: {x: {$in: [1, 2, 3, 4, 5, 6]}}} 
             ]});
 
 /**
- * Setup: creates a collection with 4800 documents of the form {x : i}
+ * Setup: creates a collection with documents of the form {x : i}
  * Test: Finds all documents with x between 1 and 6 using a $where query
  */
 tests.push({name: "Where.In.Where",
             tags: ['query','where'],
-            pre: generateSimpleDocs,
+            pre: function(collection) {
+                generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
               {op: "find", query: {$where: function() {
                   for (var j = 1; j <= 6; j++) {
@@ -78,42 +196,31 @@ tests.push({name: "Where.In.Where",
             ]});
 
 /**
- * Helper function to generate a collection with 4800 documents containing arrays of 10 
- * random numbers between 0 and 100
- */
- function generateArrayDocs(collection) {
-    collection.drop();
-    for (var i = 0; i < 1000; i++) {
-        var numbers = [];
-        for (var j = 0; j < 10; j++) {
-          numbers.push(Math.floor(Math.random() * 101));
-        }
-        collection.insert({results: numbers});
-    }
- }
-
-/**
- * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * Setup: creates a collection with documents containing arrays of 10 
  * random numbers between 0 and 100
  * Test: Finds all documents with x containing y such that 80 <= y < 85 
  * using $elemMatch
  */
 tests.push({name: "Where.ElemMatch.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generateArrayDocs,
+            pre: function(collection) {
+              generateDocs(collection, 1000, arrayGenerator())
+            },
             ops: [
               {op: "find", query: {results: {$elemMatch: {$gte: 80, $lt: 85 }}}}
             ]});
 
 /**
- * Setup: creates a collection with 4800 documents containing arrays of 10 
+ * Setup: creates a collection with documents containing arrays of 10 
  * random numbers between 0 and 100
  * Test: Finds all documents with x containing y such that 80 <= y < 85 
  * using a $where query
  */
 tests.push({name: "Where.ElemMatch.Where",
             tags: ['query','where'],
-            pre: generateArrayDocs,
+            pre: function(collection) {
+              generateDocs(collection, 1000, arrayGenerator())
+            }
             ops: [
               {op: "find", query: {$where : function() {
                 for (result in this.results) {
@@ -125,27 +232,6 @@ tests.push({name: "Where.ElemMatch.Where",
               }}}
             ]});
 
-/*
- * Helper function to generate permutations for Regex queries
- */
-function generatePermutationsCollection(c) {
-    var strings = [];
-    for (var i = 0; i < 26; i++) {
-        strings.push(String.fromCharCode(95+i));
-    }
-    var collection = [];
-    for (var i = 0; i < 26; i++) {
-        for (var j = 0; j < 26; j++) {
-            for (var k = 0; k < 26; k++) {
-                for (var l = 0; l < 26; l++) {
-                    collection.push({x: strings[i]+strings[j]+strings[k]+strings[l]}); 
-                }
-            }
-        }
-    }
-    c.drop();
-    c.insert(collection);
-}
 
 /*
  * Setup: Create collection with documents containing 4 character alphabetic permutations
@@ -153,9 +239,11 @@ function generatePermutationsCollection(c) {
  */
 tests.push({name: "Where.v1.Regex.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generatePermutationsCollection,
+            pre: function(collection) {
+              generateDocs(collection, Math.pow(26, 4), permutationGenerator())
+            },
             ops: [
-                {op: "find", query: { x : /^aa/ } }
+              {op: "find", query: { x : /^aa/ } }
             ]
             } );
 
@@ -165,39 +253,13 @@ tests.push({name: "Where.v1.Regex.QueryLanguage",
  */
 tests.push({name: "Where.v1.Regex.Where",
             tags: ['query','where'],
-            pre: generatePermutationsCollection,
+            pre: function(collection) {
+              generateDocs(collection, Math.pow(26, 4), permutationGenerator())
+            },
             ops: [
-                {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); }}}
+              {op: "find", query: { '$where' : function() { return /^aa/.test(this.x); }}}
             ]
             } );
-
-/*
- * Helper function to generate collection of deeply nested documents
- */
-function generateNestedCollection(c) {
-    var strings = [];
-    for (var i = 0; i < 26; i++) {
-        strings.push(String.fromCharCode(95+i));
-    }
-    var collection = [];
-    for (var i = 0; i < 13; i++) {
-        collection[i] = {};
-        for (var j = 0; j < 13; j++) {
-            collection[i][strings[j]] = {};
-            for (var k = 0; k < 13; k++) {
-                collection[i][strings[j]][strings[k]] = {};
-                for (var l = 0; l < 13; l++) {
-                    collection[i][strings[j]][strings[k]][strings[l]] = {};
-                    for (var m = 0; m < 13; m++) {
-                        collection[i][strings[j]][strings[k]][strings[l]][strings[m]] = i + j + k + l + m;
-                    }
-                }
-            }
-        }
-    }
-    c.drop();
-    c.insert(collection);
-}
 
 /*
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
@@ -205,9 +267,11 @@ function generateNestedCollection(c) {
  */
 tests.push({name: "Where.v1.SimpleNested.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generateNestedCollection,
+            pre: function(collection) {
+              generateDocs(collection, 13, nestedGenerator())
+            },
             ops: [
-                {op: "find", query: { 'd.c.b.a' : 1 } }
+              {op: "find", query: { 'd.c.b.a' : 1 } }
             ]
             } );
 
@@ -217,25 +281,15 @@ tests.push({name: "Where.v1.SimpleNested.QueryLanguage",
  */
 tests.push({name: "Where.v1.SimpleNested.Where",
             tags: ['query', 'where'],
-            pre: generateNestedCollection,
+            pre: function(collection) {
+              generateDocs(collection, 13, nestedGenerator(false))
+            },
             ops: [
-                {op:"find", query: {'$where': function() { return this.d.c.b.a === 1 }}}
+              {op:"find", query: {'$where': function() { return this.d.c.b.a === 1 }}}
             ]   
             } );
 
 // Queries that require the use of $where
-
-/**
- * Helper function to generate a collection with 40,000 documents of the form {x: i, y: j}
- */
- function generateTupleDocs(collection) {
-    collection.drop();
-    for (var i = 0; i < 200; i++) {
-      for (var j = 0; j < 200; j++) {
-        collection.insert({x: i, y: j});
-      }
-    }
- }
 
 /**
  * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
@@ -243,7 +297,9 @@ tests.push({name: "Where.v1.SimpleNested.Where",
  */
 tests.push({name: "Where.CompareFields.Equals",
             tags: ['query','where'],
-            pre: generateTupleDocs,
+            pre: function(collection) {
+              generateDocs(collection, 1000, increasingXGenerator())
+            },
             ops: [
               {op: "find", query: {$where: function() {return this.x == this.y}}} 
             ]});
@@ -254,7 +310,9 @@ tests.push({name: "Where.CompareFields.Equals",
  */
 tests.push({name: "Where.CompareFields.Gt",
             tags: ['query','where'],
-            pre: generateTupleDocs,
+            pre: function(collection) {
+              generateDocs(collection, 200, tupleGenerator(200))
+            },
             ops: [
               {op: "find", query: {$where: function() {return this.x > this.y}}} 
             ]});
@@ -265,7 +323,9 @@ tests.push({name: "Where.CompareFields.Gt",
  */
 tests.push({name: "Where.CompareFields.Gte",
             tags: ['query','where'],
-            pre: generateTupleDocs,
+            pre: function(collection) {
+              generateDocs(collection, 200, tupleGenerator(200))
+            },
             ops: [
               {op: "find", query: {$where: function() {return this.x >= this.y}}} 
             ]});
@@ -276,7 +336,9 @@ tests.push({name: "Where.CompareFields.Gte",
  */
 tests.push({name: "Where.CompareFields.Lt",
             tags: ['query','where'],
-            pre: generateTupleDocs,
+            pre: function(collection) {
+              generateDocs(collection, 200, tupleGenerator(200))
+            },
             ops: [
               {op: "find", query: {$where: function() {return this.x < this.y}}}
             ]});
@@ -286,11 +348,13 @@ tests.push({name: "Where.CompareFields.Lt",
  * Test: Finds all documents where x <= y
  */
 tests.push({name: "Where.CompareFields.Lte",
-              tags: ['query','where'],
-              pre: generateTupleDocs,
-              ops: [
-                {op: "find", query: {$where: function() {return this.x <= this.y}}}
-              ]});
+            tags: ['query','where'],
+            pre: function(collection) {
+              generateDocs(collection, 200, tupleGenerator(200))
+            },
+            ops: [
+              {op: "find", query: {$where: function() {return this.x <= this.y}}}
+            ]});
 
 /**
  * Setup: creates a collection with 40,000 documents of the form {x: i, y: j}
@@ -298,7 +362,9 @@ tests.push({name: "Where.CompareFields.Lte",
  */
 tests.push({name: "Where.Mixed",
             tags: ['query','where','querylanguage'],
-            pre: generateTupleDocs,
+            pre: function(collection) {
+              generateDocs(collection, 200, tupleGenerator(200))
+            },
             ops: [
               {op: "find", query: {$or : [{x: 2}, {$where: function() {return (this.y == 3);}}]}} 
             ]});
@@ -309,41 +375,15 @@ tests.push({name: "Where.Mixed",
  */
 tests.push({name: "Where.v1.ComplexNested",
             tags: ['query','where'],
-            pre: generateNestedCollection,
+            pre: function(collection) {
+              generateDocs(collection, 10, nestedGenerator(true))
+            }
             ops: [
-                {op: "find", query: {'$where': function() { return this.d.c.b.a === this.a.b.c.d }}}
+              {op: "find", query: {'$where': function() { return this.d.c.b.a === this.a.b.c.d }}}
             ]   
             } );
 
 // Queries to experiment with document size
-
-/*
- * Helper function to generate collection with large deeply nested documents
- */
-function generateBigDeeplyNestedCollection(c) {
-    var strings = [];
-    for (var i = 0; i < 26; i++) {
-        strings.push(String.fromCharCode(95+i));
-    }
-    var collection = [];
-    for (var i = 0; i < 10; i++) {
-        collection[i] = {};
-        for (var j = 0; j < 26; j++) {
-            collection[i][strings[j]] = {};
-            for (var k = 0; k < 26; k++) {
-                collection[i][strings[j]][strings[k]] = {};
-                for (var l = 0; l < 26; l++) {
-                    collection[i][strings[j]][strings[k]][strings[l]] = {};
-                    for (var m = 0; m < 26; m++) {
-                        collection[i][strings[j]][strings[k]][strings[l]][strings[m]] = i + j + k + l + m;
-                    }
-                }
-            }
-        }
-    }
-    c.drop();
-    c.insert(collection);
-}
 
 /*
  * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
@@ -351,9 +391,11 @@ function generateBigDeeplyNestedCollection(c) {
  */
 tests.push({name: "Where.v1.ReallyBigNestedComparison.QueryLanguage",
             tags: ['query','querylanguage'],
-            pre: generateBigDeeplyNestedCollection,
+            pre: function(collection) {
+              generateDocs(collection, 10, nestedGenerator(true))
+            }
             ops: [
-                {op: "find", query: { 'a.b.c.d' : 1 }}
+              {op: "find", query: { 'a.b.c.d' : 1 }}
             ]
             } );
 
@@ -363,8 +405,10 @@ tests.push({name: "Where.v1.ReallyBigNestedComparison.QueryLanguage",
  */
 tests.push({name: "Where.v1.ReallyBigNestedComparison.Where",
             tags: ['query','where'],
-            pre: generateBigDeeplyNestedCollection,
+            pre: function(collection) {
+              generateDocs(collection, 10, nestedGenerator(true))
+            }
             ops: [
-                {op: "find", query: {'$where': function() { return this.a.b.c.d == 1; }}} 
+              {op: "find", query: {'$where': function() { return this.a.b.c.d == 1; }}} 
             ]
             } );

--- a/testcases/where.js
+++ b/testcases/where.js
@@ -129,7 +129,7 @@ function nestedGenerator(big) {
  * Test: Finds {x: 1} using query language
  */
 tests.push({name: "Where.CompareToInt.QueryLanguage",
-            tags: ['query','querylanguage','compare'],
+            tags: ['query','compare'],
             pre: generateDocs(1000, increasingXGenerator()),
             ops: [
               {op: "find", query: {x : 1}}
@@ -140,7 +140,7 @@ tests.push({name: "Where.CompareToInt.QueryLanguage",
  * Test: Finds {x: 1} using a $where query with == (weak equality)
  */
 tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
-            tags: ['query','where','compare'],
+            tags: ['query','where'],
             pre: generateDocs(1000, increasingXGenerator()),
             ops: [
               {op: "find", query: {$where: function() {return this.x == 1;}}} 
@@ -151,7 +151,7 @@ tests.push({name: "Where.CompareToInt.Where.DoubleEquals",
  * Test: Finds {x: 1} using a $where query with === (type-safe equality)
  */
 tests.push({name: "Where.CompareToInt.Where.TripleEquals",
-            tags: ['query','where','compare'],
+            tags: ['query','where'],
             pre: generateDocs(1000, increasingXGenerator()),
             ops: [
               {op: "find", query: {$where: function() {return this.x === 1;}}} 
@@ -181,7 +181,7 @@ tests.push({name: "Where.In.Where",
  * Test: Finds all documents with x between 1 and 6 using $in 
  */
 tests.push({name: "Where.In.QueryLanguage",
-            tags: ['query','querylanguage'],
+            tags: ['query','compare'],
             pre: generateDocs(1000, increasingXGenerator()),
             ops: [
               {op: "find", query: {x: {$in: [1, 2, 3, 4, 5, 6]}}} 
@@ -214,7 +214,7 @@ tests.push({name: "Where.ElemMatch.Where",
  * using $elemMatch
  */
 tests.push({name: "Where.ElemMatch.QueryLanguage",
-            tags: ['query','querylanguage'],
+            tags: ['query','compare'],
             pre: generateDocs(1000, arrayGenerator),
             ops: [
               {op: "find", query: {results: {$elemMatch: {$gte: 80, $lt: 85 }}}}
@@ -224,7 +224,7 @@ tests.push({name: "Where.ElemMatch.QueryLanguage",
  * Setup: Create collection with documents containing 4 character alphabetic permutations
  * Test: Find document based on Regex $where
  */
-tests.push({name: "Where.v1.Regex.Where",
+tests.push({name: "Where.Regex.Where",
             tags: ['query','where'],
             pre: generateDocs(Math.pow(26, 4), permutationGenerator()),
             ops: [
@@ -236,8 +236,8 @@ tests.push({name: "Where.v1.Regex.Where",
  * Setup: Create collection with documents containing 4 character alphabetic permutations
  * Test: Find document based on Regex Query
  */
-tests.push({name: "Where.v1.Regex.QueryLanguage",
-            tags: ['query','querylanguage'],
+tests.push({name: "Where.Regex.QueryLanguage",
+            tags: ['query','compare'],
             pre: generateDocs(Math.pow(26, 4), permutationGenerator()),
             ops: [
               {op: "find", query: { x : /^aa/ } }
@@ -248,7 +248,7 @@ tests.push({name: "Where.v1.Regex.QueryLanguage",
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of deeply nested field using $where
  */
-tests.push({name: "Where.v1.SimpleNested.Where",
+tests.push({name: "Where.SimpleNested.Where",
             tags: ['query', 'where'],
             pre: generateDocs(13, nestedGenerator(false)),
             ops: [
@@ -260,8 +260,8 @@ tests.push({name: "Where.v1.SimpleNested.Where",
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of deeply nested field using Query Language
  */
-tests.push({name: "Where.v1.SimpleNested.QueryLanguage",
-            tags: ['query','querylanguage'],
+tests.push({name: "Where.SimpleNested.QueryLanguage",
+            tags: ['query','compare'],
             pre: generateDocs(13, nestedGenerator()),
             ops: [
               {op: "find", query: { 'd.c.b.a' : 1 } }
@@ -330,7 +330,7 @@ tests.push({name: "Where.CompareFields.Lte",
  * Test: Finds all documents where x == 2 or y == 3 
  */
 tests.push({name: "Where.Mixed",
-            tags: ['query','where','querylanguage'],
+            tags: ['query','where'],
             pre: generateDocs(200, tupleGenerator(200)),
             ops: [
               {op: "find", query: {$or : [{x: 2}, {$where: function() {return (this.y == 3);}}]}} 
@@ -340,7 +340,7 @@ tests.push({name: "Where.Mixed",
  * Setup: Creates a collection of 13 objects, each with 4 nested levels of 13 fields
  * Test: Find document through match of two deeply nested fields on the same document using $where
  */
-tests.push({name: "Where.v1.ComplexNested",
+tests.push({name: "Where.ComplexNested",
             tags: ['query','where'],
             pre: generateDocs(10, nestedGenerator(true)),
             ops: [
@@ -354,7 +354,7 @@ tests.push({name: "Where.v1.ComplexNested",
  * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
  * Test: Find document through match of a deeply nested field using $where 
  */
-tests.push({name: "Where.v1.ReallyBigNestedComparison.Where",
+tests.push({name: "Where.ReallyBigNestedComparison.Where",
             tags: ['query','where'],
             pre: generateDocs(10, nestedGenerator(true)),
             ops: [
@@ -366,8 +366,8 @@ tests.push({name: "Where.v1.ReallyBigNestedComparison.Where",
  * Setup: Creates a collection of 10 documents, each with 4 nested levels of 26 fields
  * Test: Find document through match of a deeply nested field using query language
  */
-tests.push({name: "Where.v1.ReallyBigNestedComparison.QueryLanguage",
-            tags: ['query','querylanguage'],
+tests.push({name: "Where.ReallyBigNestedComparison.QueryLanguage",
+            tags: ['query','compare'],
             pre: generateDocs(10, nestedGenerator(true)),
             ops: [
               {op: "find", query: { 'a.b.c.d' : 1 }}


### PR DESCRIPTION
## Compares performance between queries using the query language and the $where operator.

- Comparing a field in a document to a static integer
- $in
- $elemMatch
- Regex
- Querying nested field, match to a static integer

## Checks performance for more complicated queries using $where

- Comparison between two fields in the same document
- Mixed query using query language and $where
- Comparison between two nested fields in the same document

## Document Shape and Size Experimentation

- Query a collection of very large documents with deeply nested fields using both, query language and $where