### PR TITLE
Use the hostname provided as argument

### DIFF
--- a/benchrun.py
+++ b/benchrun.py
@@ -150,14 +150,14 @@ def main():
             args.includeFilter = '%'
 
     # Print version info.
-    call([args.shellpath, "--norc", "--port", args.port, "--eval",
+    call([args.shellpath, "--norc", "--host", args.hostname, "--port", args.port, "--eval",
           "print('db version: ' + db.version());"
           " db.serverBuildInfo().gitVersion;"])
     print("")
 
 
     # Open a mongo shell subprocess and load necessary files.
-    mongo_proc = Popen([args.shellpath, "--norc", "--quiet", "--port", args.port], stdin=PIPE, stdout=PIPE)
+    mongo_proc = Popen([args.shellpath, "--norc", "--quiet", "--host", args.hostname, "--port", args.port], stdin=PIPE, stdout=PIPE)
 
     # load test files
     load_file_in_shell(mongo_proc, 'util/utils.js')


### PR DESCRIPTION
Although the argument was being parsed before, it was never being used.

This patch uses the argument in the two calls out to the mongo client.

The only problem I can imagine this might cause is if for some reason the default hostname "localhost" does not work on some machines.  (Presumably the user could fix that by passing `--host 127.0.1.1` or whatever.)
