### PR TITLE
Pass --host arg to shell calls

### DIFF
--- a/benchrun.py
+++ b/benchrun.py
@@ -150,14 +150,16 @@ def main():
             args.includeFilter = '%'
 
     # Print version info.
-    call([args.shellpath, "--norc", "--port", args.port, "--eval",
-          "print('db version: ' + db.version());"
+    call([args.shellpath, "--norc",
+          "--host", args.hostname, "--port", args.port,
+          "--eval", "print('db version: ' + db.version());"
           " db.serverBuildInfo().gitVersion;"])
     print("")
 
-
     # Open a mongo shell subprocess and load necessary files.
-    mongo_proc = Popen([args.shellpath, "--norc", "--quiet", "--port", args.port], stdin=PIPE, stdout=PIPE)
+    mongo_proc = Popen([args.shellpath, "--norc", "--quiet",
+                       "--host", args.hostname, "--port", args.port],
+                       stdin=PIPE, stdout=PIPE)
 
     # load test files
     load_file_in_shell(mongo_proc, 'util/utils.js')


### PR DESCRIPTION
`host` argument of `benchrun.py` described at help but mongo shell calls in code use only `port` argument. I pass `host` argument to shell calls to get ability to specify mongo host.
