### PR TITLE
PERF-1454: Move Insert.LargeDocVector to be last in the task - again

### DIFF
--- a/testcases/simple_insert.js
+++ b/testcases/simple_insert.js
@@ -247,20 +247,6 @@ tests.push( { name: "InsertIndexedStringsNonSimpleCollation",
               ] } );
 
 /*
- * Setup:
- * Test: Insert a vector of large documents. Each document contains a long string
- * Notes: Generates the _id field on the client
- *        
- */
-tests.push( { name: "Insert.LargeDocVector",
-              tags: ['insert','regression'],
-              pre: function( collection ) { collection.drop(); },
-              ops: [
-                  { op:  "insert",
-                    doc: docs }
-              ] } );
-
-/*
  * Setup: Create an empty collection and a unique index on a field.
  * Test: Insert documents into collection using sequential int for the indexed
  *            field.
@@ -333,3 +319,22 @@ tests.push( { name: "Insert.UniqueIndexCompoundReverse",
                         b: { "#SEQ_INT":
                             { seq_id: 0, start: 0, step: 1, unique: true } } } }
               ] } );
+
+/*
+ * Setup:
+ * Test: Insert a vector of large documents. Each document contains a long string
+ * Notes: Generates the _id field on the client. This test should remain the last test in the file. 
+ *        
+ */
+tests.push( { name: "Insert.LargeDocVector",
+              tags: ['insert','regression'],
+              pre: function( collection ) { collection.drop(); },
+              ops: [
+                  { op:  "insert",
+                    doc: docs }
+              ] } );
+
+
+/*
+ * Note: Please do not add tests after Insert.LargeDocVector. Add new tests before it. 
+ */


### PR DESCRIPTION
Patch build here: https://evergreen.mongodb.com/version/5af213e8e3c33109e3ca2185
