### PR TITLE
PERF-2028 IncFewLargeDocLongFields is measuring a query that fails

### DIFF
--- a/testcases/pipeline_update.js
+++ b/testcases/pipeline_update.js
@@ -71,7 +71,7 @@ var longFieldNames = [
  * collection by _id field, and increments the same 5 of the 20 integer fields in the document.
  */
 tests.push({
-    name: "PipelineUpdate.IncFewLargeDocLongFields",
+    name: "PipelineUpdate.IncrementFewKeysLargeDocLongFields",
     tags: ["regression", "pipeline-updates", "regression", ">=4.2.0"],
     pre: function(collection) {
         collection.drop();

--- a/testcases/pipeline_update.js
+++ b/testcases/pipeline_update.js
@@ -98,11 +98,11 @@ tests.push({
           update: [
               {
                 $set: {
-                    kbgcslcybg: ["$kbgcslcybg", 1],
-                    vjhgznppgw: ["$vjhgznppgw", 1],
-                    jzaathnsra: ["$jzaathnsra", 1],
-                    miohmkbzvv: ["$miohmkbzvv", 1],
-                    elcgijivrt: ["$elcgijivrt", 1],
+                    kbgcslcybg: {$add: ["$kbgcslcybg", 1]},
+                    vjhgznppgw: {$add: ["$vjhgznppgw", 1]},
+                    jzaathnsra: {$add: ["$jzaathnsra", 1]},
+                    miohmkbzvv: {$add: ["$miohmkbzvv", 1]},
+                    elcgijivrt: {$add: ["$elcgijivrt", 1]},
                 },
               },
           ],


### PR DESCRIPTION
Fix the erroneous microbenchmark. I've run two evergreen patch builds for this new microbenchmark before and after generating $v:2 oplog entries. The regression now is within 1%.


est                                                                                          | 1          | 2        | 4          | 8          | Max
--                                                                                            | --        | --       | --         | --          | --
PipelineUpdate.IncFewLargeDocLongFields (Before v:2) | 4,803 | 9,463 | 16,434 | 18,523 | 18,523     
--                                                                                            | --        | --       | --         | --         | --        
PipelineUpdate.IncFewLargeDocLongFields (After v:2 and optimizing diffing code   ) | 4,674 | 9,272 | 16,114 | 18,355 | 18,355      

Regression = (18,523 - 18,355) / 18,523 = 0.00907

[Evergreen link](https://evergreen.mongodb.com/task/performance_linux_wt_repl_pipeline_updates_patch_3f525f9a925f7aa979c644b6c5a99bc29c9e466d_5f58139fe3c3314917503abc_20_09_08_23_28_56#)
