### PR TITLE
SERVER-58309 Delete logic surrounding the now-deprecated safe mode

### DIFF
--- a/benchrun.py
+++ b/benchrun.py
@@ -57,10 +57,6 @@ def parse_arguments():
     parser.add_argument('-s', '--shell', dest='shellpath',
                         help="Path to the mongo shell executable to use.",
                         default='mongo')
-    parser.add_argument('--safe', dest='safeMode',
-                        nargs='?', const='true', choices=['true', 'false'],
-                        help='this option enables a call to GLE after every op instead of every 100 ops',
-                        default='false')
     parser.add_argument('-w', dest='w',
                         help='w write concern',
                         type=int, default=0)
@@ -180,7 +176,6 @@ def main():
 
     # put all crud options in a Map
     crud_options = {}
-    crud_options["safeGLE"] = args.safeMode
     crud_options["writeConcern"] = {}
     if (args.j):
             crud_options["writeConcern"]["j"] = args.j

--- a/gui/static/js/main.js
+++ b/gui/static/js/main.js
@@ -25,13 +25,6 @@ function format(d) {
     //var threads = d.threads.join(', ');
 
     if(d.crudOptions) {
-        var safe_icon = 'fa-check';
-        var safe_class = 'crudOptionTrue';
-        if (d.crudOptions.safeGLE == 'false') {
-            safe_icon = 'fa-times';
-            safe_class = 'crudOptionFalse';
-        }
-
         var writecmdmode_icon = 'fa-check';
         var writecmdmode_class = 'crudOptionTrue';
         if (d.crudOptions.writeCmdMode == 'false') {
@@ -82,7 +75,6 @@ function format(d) {
         '<td>CRUD Options:</td>' +
         '<td>' +
         (!d.crudOptions ? " unavailable " :
-        '<div class="crudOptionCell ' + safe_class + '">&nbsp;safe:&nbsp;<i class="fa fa-fw ' + safe_icon + '"></i></div>' +
         '<div class="crudOptionCell ' + writecmdmode_class + '">&nbsp;write cmd:&nbsp;<i class="fa fa-fw ' + writecmdmode_icon + '"></i></div>' +
         '<div class="crudOptionCell ' + readcmdmode_class + '">&nbsp;read cmd:&nbsp;<i class="fa fa-fw ' + readcmdmode_icon + '"></i></div>' +
         '<div class="crudOptionCell ' + j_class + '">&nbsp;j:&nbsp;<i class="fa fa-fw ' + j_icon + '"></i></div>' +

--- a/util/utils.js
+++ b/util/utils.js
@@ -306,8 +306,6 @@ function runTest(test, thread, multidb, multicoll, runSeconds, shard, crudOption
 
     // set crud options
     new_ops.forEach(function (z) {
-        //  when true, safe mode calls GLE after every op
-        z.safe = (crudOptions.safeGLE.toLowerCase() == 'true' ? true : false)
         //  w write concern (integer)
         z.writeConcern = crudOptions.writeConcern
         if (typeof(z.writeConcern.j) == "string") {
@@ -477,7 +475,6 @@ function setFieldPathArrayToValue(object, pathAsArray, value) {
 
 function getDefaultCrudOptions() {
     var crudOptions = {};
-    crudOptions.safeGLE = 'false';
     crudOptions.writeConcern = {};
     crudOptions.writeCmdMode = 'true';
     crudOptions.readCmdMode = 'false';


### PR DESCRIPTION
Due to failures in [this perf patch](https://spruce.mongodb.com/version/60f992f41e2d174cc3663d1d/tasks), I'm deleting all logic relating to safe mode from the mongo-perf repo as well.