### PR TITLE
PERF-2639 Add --shareDataset option to benchrun.py

### DIFF
--- a/benchrun.py
+++ b/benchrun.py
@@ -105,6 +105,9 @@ def parse_arguments():
                         'equivalent to the operations performed in the list of specified JS test\n'
                         'files without actually running the test cases. A mongod process must\n'
                         'still be running while the JSON config files are being generated.')
+    parser.add_argument('--shareDataset', dest='shareDataset', nargs='?', const='true',
+                        choices=['true','false'], default='false',
+                        help='Share the dataset, created by the first test with all following tests/trials.')
     return parser
 
 
@@ -211,6 +214,7 @@ def main():
               str(json.dumps(crud_options)) + ", " +
               str(args.excludeTestbed) + ", " +
               str(args.printArgs) + ", " +
+              str(args.shareDataset) + ", " +
               str(json.dumps(mongoebench_options)) +
               authstr +
               ");")

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -185,6 +185,42 @@ function generateTestCase(options) {
     });
 }
 
+function generateTestCaseWithLargeDataset(options) {
+    var nDocs = options.nDocs || 100000;
+    var pipeline = options.pipeline;
+    var tags = options.tags || [];
+
+    tests.push({
+        tags: ["regression", "aggregation_large_dataset"].concat(tags),
+        name: "Aggregation." + options.name,
+        gen: options.gen ||
+            function(collection) {
+                Random.setRandomSeed(258);
+                collection.drop();
+                var bulkop = collection.initializeUnorderedBulkOp();
+                for (var i = 0; i < nDocs; i++) {
+                    bulkop.insert(options.docGenerator(i));
+                }
+                bulkop.execute();
+            },
+        pre: options.pre || function (collection) {},
+        post: options.post || function(collection) {},
+        ops: [{
+            op: "command",
+            ns: "#B_DB",
+            command: {aggregate: "#B_COLL", pipeline: pipeline, cursor: {}}
+        }]
+    });
+}
+
+generateTestCaseWithLargeDataset({
+    name: "TestSharedDataset",
+    docGenerator: function basicGroupDocGenerator(i) {
+        return {_id: i, _idMod10: i % 10};
+    },
+    pipeline: [{$group: {_id: "$_idMod10"}}]
+});
+
 //
 // Empty pipeline.
 //

--- a/util/utils.js
+++ b/util/utils.js
@@ -263,14 +263,76 @@ function CommandTracer(testName, options) {
     }
 }
 
-function runTest(test, thread, multidb, multicoll, runSeconds, shard, crudOptions, printArgs, mongoeBenchOptions, username, password) {
+var sharedCollections = [];
+function initCollections(collections, env, testName, init, multidb, multicoll, shard) {
+    for (var i = 0; i < multidb; i++) {
+        var sibling_db = db.getSiblingDB('test' + i);
+        var foo = testName.replace(/\./g, "_");
+        for (var j = 0; j < multicoll; j++) {
+            var coll = sibling_db.getCollection(foo + j);
+            collections.push(coll);
+            coll.drop();
+        }
+    }
+
+    if (init) {
+        for (var i = 0; i < (multidb * multicoll); i++) {
+            init(collections[i], env);
+        }
+    }
+
+    // If the 'dataGen' or 'pre' functions did not create the collections, then we should
+    // explicitly do so now. We want the collections to be pre-allocated so that allocation time is 
+    // not incorporated into the benchmark.
+    for (var i = 0; i < multidb; i++) {
+        var theDb = db.getSiblingDB('test' + i);
+        // This will silently fail and with no side-effects if the collection
+        // already exists.
+        for (var j = 0; j < multicoll; j++) {
+            theDb.createCollection(collections[(multicoll * i) + j].getName());
+        }
+
+        if (shard == 1) {
+            for (var j = 0; j < multicoll; j++) {
+                // when shard is enabled, we want to enable shard
+                collections[(multicoll * i) + j].createIndex({ _id: "hashed" });
+            }
+
+            sh.enableSharding("test" + i);
+            for (var j = 0; j < multicoll; j++) {
+                var t = sh.shardCollection("test" + i + "." +
+                    collections[(multicoll * i) + j].getName(), { _id: "hashed" });
+            }
+
+        } else if (shard == 2) {
+            sh.enableSharding("test" + i);
+            for (var j = 0; j < multicoll; j++) {
+                var t = sh.shardCollection("test" + i + "." +
+                    collections[(multicoll * i) + j].getName(), { _id: 1 });
+            }
+        }
+    }
+}
+
+function cleanupCollections(collections, multidb, multicoll) {
+    for (var i = 0; i < multidb; i++) {
+        for (var j = 0; j < multicoll; j++) {
+            collections[(multicoll * i) + j].drop();
+        }
+    }
+
+    // Make sure all collections have been dropped
+    checkForDroppedCollectionsTestDBs(db, multidb)
+}
+
+function runTest(
+    test, thread, multidb, multicoll, runSeconds, shard, crudOptions, printArgs, shareDataset,
+    mongoeBenchOptions, username, password) {
 
     if (typeof crudOptions === "undefined") crudOptions = getDefaultCrudOptions();
     if (typeof shard === "undefined") shard = 0;
     if (typeof includeFilter === "undefined") includeFilter = "sanity";
     if (typeof printArgs === "undefined") printArgs = false;
-
-    var collections = [];
 
     var realTracer = new CommandTracer(test.name, mongoeBenchOptions);
     var fakeTracer = {};
@@ -282,14 +344,32 @@ function runTest(test, thread, multidb, multicoll, runSeconds, shard, crudOption
     var tracer = mongoeBenchOptions.traceOnly ? realTracer : fakeTracer;
     tracer.beginPre();
 
-    for (var i = 0; i < multidb; i++) {
-        var sibling_db = db.getSiblingDB('test' + i);
-        var foo = test.name.replace(/\./g,"_");
-        for (var j = 0; j < multicoll; j++) {
-            var coll = sibling_db.getCollection(foo + j);
-            collections.push(coll);
-            coll.drop();
+    // setup an environment to pass to the pre and post
+    var env = {
+        threads: thread
+    };
+
+    var collections = shareDataset ? sharedCollections : [];
+    // For sharing of collections' data between tests in the same suite, the tests MUST provide
+    // 'gen' function that is executed once (from the test that happens to run first). The tests
+    // MIGHT also provide 'pre' and 'post' fixtures to create indexes, etc. These functions are
+    // exectuted per test. The matter is complicated by the fact that existing tests use 'pre' for
+    // creating the data and setting up additional stuff, and we don't want to modify these
+    // tests. On the other hand, the future tests might want to use both 'gen' and 'pre' without
+    // sharing the dataset.
+    if ("gen" in test) {
+        if (!shareDataset || collections.length == 0) {
+            initCollections(collections, env, test.name, test.gen, multidb, multicoll, shard);
         }
+        if ("pre" in test) {
+            for (var i = 0; i < (multidb * multicoll); i++) {
+                test.pre(collections[i], env);
+            }
+        }
+    }
+    else {
+        assert(!shareDataset);
+        initCollections(collections, env, test.name, test.pre, multidb, multicoll, shard);
     }
 
     var new_ops = [];
@@ -317,49 +397,6 @@ function runTest(test, thread, multidb, multicoll, runSeconds, shard, crudOption
         //  same as 'writeCmd', but for read commands
         z.readCmd = (crudOptions.readCmdMode.toLowerCase() == 'true' ? true : false)
     });
-
-    // setup an environment to pass to the pre and post
-    var env = {
-        threads: thread
-    };
-
-    if ("pre" in test) {
-        for (var i = 0; i < (multidb * multicoll); i++) {
-            test.pre(collections[i], env);
-        }
-    }
-
-    // If the 'pre' function did not create the collections, then we should
-    // explicitly do so now. We want the collections to be pre-allocated so
-    // that allocation time is not incorporated into the benchmark.
-    for (var i = 0; i < multidb; i++) {
-        var theDb = db.getSiblingDB('test' + i);
-        // This will silently fail and with no side-effects if the collection
-        // already exists.
-        for (var j = 0; j < multicoll; j++) {
-            theDb.createCollection(collections[(multicoll * i) + j].getName());
-        }
-
-        if (shard == 1) {
-            for (var j = 0; j < multicoll; j++) {
-                // when shard is enabled, we want to enable shard
-                collections[(multicoll * i) + j].createIndex({ _id: "hashed" });
-            }
-
-            sh.enableSharding("test" + i);
-            for (var j = 0; j < multicoll; j++) {
-                var t = sh.shardCollection("test" + i + "." +
-                    collections[(multicoll * i) + j].getName(), {_id: "hashed"});
-            }
-
-        } else if (shard == 2) {
-            sh.enableSharding("test" + i);
-            for (var j = 0; j < multicoll; j++) {
-                var t = sh.shardCollection("test" + i + "." +
-                    collections[(multicoll * i) + j].getName(), {_id: 1});
-                }
-        }
-    }
 
     tracer.beginOps();
 
@@ -419,14 +456,9 @@ function runTest(test, thread, multidb, multicoll, runSeconds, shard, crudOption
     tracer.done();
 
     // drop all the collections created by this case
-    for (var i = 0; i < multidb; i++) {
-        for (var j = 0; j < multicoll; j++) {
-            collections[(multicoll * i) + j].drop();
-        }
+    if (!shareDataset) {
+        cleanupCollections(collections);
     }
-
-    // Make sure all collections have been dropped
-    checkForDroppedCollectionsTestDBs(db, multidb)
 
     return { ops_per_sec: total, error_count : result["errCount"]};
 }


### PR DESCRIPTION
Split out from https://github.com/mongodb/mongo-perf/pull/84 the changes to benchrun and utils. Changes in pipelines.js are only to demonstrate (and test locally) how this new argument could be used. I'll revert it before merging.

The change is supposed to be purely additive and have no effect on the existing tests. I've kicked off Evergreen run https://spruce.mongodb.com/version/6171e8cc0305b9455baad8fa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC with a few tasks for sanity testing. Is this sufficient or should I run more?