### PR TITLE
PERF-2486 Add performance tests for $bottom/$top/$bottomN/$topN accumulators

### DIFF
--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -545,7 +545,7 @@ generateTestCase({
 /**
  * Test cases similar to the minN/maxN group tests but for top/bottom/topN/bottomN. It splits 1000
  * documents into 10 groups of 100 and returns the 10 most desired values in each group, or just one
- * in the cases of top/bottom. documents are arranged in either ascending or decending order so that
+ * in the cases of top/bottom. Documents are arranged in either ascending or decending order so that
  * the number of comparisons and evictions performed is maximized.
  */
 [

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -542,6 +542,37 @@ generateTestCase({
             output: {lastVals: {$lastN: {n: 10, output: "$_id"}, window: {range: [-10, 10]}}}}}]
 });
 
+/**
+ * Test cases similar to the minN/maxN group tests but for top/bottom/topN/bottomN. It splits 1000
+ * documents into 10 groups of 100 and returns the 10 most desired values in each group, or just one
+ * in the cases of top/bottom. documents are arranged in either ascending or decending order so that
+ * the number of comparisons and evictions performed is maximized.
+ */
+[
+    {name: "Top", op: "$top", direction: -1},
+    {name: "Bottom", op: "$bottom", direction: 1},
+    {name: "TopN", op: "$topN", direction: -1, n: 10},
+    {name: "BottomN", op: "$bottomN", direction: 1, n: 10}
+].forEach(({name, op, direction, n}) => {
+    generateTestCase({
+        name: "Group.TenGroupsWith" + name,
+        tags: ['>=5.2.0'],
+        nDocs: 1000,
+        docGenerator: (i) => ({
+            // For bottomN/bottom direction is 1 and -1 for topN/top to maximize the amount of
+            // inserts to the accumulators internal container, similar to Group.TenGroupsWithMaxN
+            _id: i * direction,
+            _idMod10: i % 10,
+            // This is just a value to output later, it doesn't really matter what it is.
+            _idMod7: i % 7
+        }),
+        pipeline: [{$group: {_id: "$_idMod10", result: {[op]: Object.assign(
+            {sortBy: {_id: 1}, output: "$_idMod7"},
+            n ? {n} : {}, // topN and bottomN also need an extra n parameter.
+        )}}}]
+    });
+});
+
 generateTestCase({
     name: "Group.TenGroupsWithSumJs",
     tags: ['js', '>=4.3.4'],


### PR DESCRIPTION
[evergreen run](https://spruce.mongodb.com/version/61800e9d61837d5ec679b2a8)

These accumulators are all very similar so I just have one parameterized test for all 4 of them. They are similar to minN/maxN but support having the output be a different value that what the documents are being sorted by.
I used some es6 JS stuff here and the build passed. I didn't see much es6 happening in this file, but if this is any issue I can refactor it to just use es5 JS.