### PR TITLE
PERF-2741 make syntax in testcases/pipelines.js compatible with older shell versions

### DIFF
--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -384,7 +384,7 @@ function topBottomTestCaseGenerator(name, op, direction, groupSize, nDocs, n = u
         docGenerator: (i) => topBottomDocGenerator(groupSize, direction, i),
         pipeline: [{$group: {_id: "$groupKey", result: {[op]: Object.assign(
                         {sortBy: {_id: 1}, output: "$_idMod7"},
-                        n ? {n} : {}, // topN and bottomN also need an extra n parameter.
+                        n ? {n} : {} // topN and bottomN also need an extra n parameter.
                     )}}}]
     });
 }
@@ -396,9 +396,9 @@ function topBottomTestCaseGenerator(name, op, direction, groupSize, nDocs, n = u
  * dimensions: {groupSize: 100, n: 10}, {groupSize: 100, n: 50}, {groupSize: 250, n: 10},
  * {groupSize: 250, n: 50}.
  */
-for (const groupSize of [100, 250]) {
+for (let groupSize of [100, 250]) {
     const nDocs = 10 * 1000;
-    for (const n of [10, 50]) {
+    for (let n of [10, 50]) {
         /**
          * This aggregation returns the top 'n' players from each game (sorted by score). It is
          * able to do this by leveraging an index on {game: 1, score: -1}.
@@ -642,7 +642,7 @@ for (const groupSize of [100, 250]) {
     [
         {name: "Top", op: "$top", direction: -1},
         {name: "Bottom", op: "$bottom", direction: 1},
-    ].forEach(({name, op, direction, n = undefined}) => {
+    ].forEach(({name, op, direction, n}) => {
         topBottomTestCaseGenerator(name, op, direction, groupSize, nDocs, n)
     });
 }
@@ -676,8 +676,8 @@ function accumulatorNExpressionDocGenerator(i, arr) {
     return {_id: i, array: arr};
 }
 
-for(const arrSize of [50, 250, 500]) {
-    for(const n of [10, 50]) {
+for(let arrSize of [50, 250, 500]) {
+    for(let n of [10, 50]) {
         const nDocs = 1000;
         /**
          * Test case which, for each document, evaluates taking the minimum 'n'' values of an array


### PR DESCRIPTION
I manually checked the syntax using this command `echo -e 'load("util/utils.js"); load("util/docGenerators.js");\n' $(ls testcases/ | awk '{print "load(\"testcases/" $1 "\");"}') |  /path/to/mongo/for/version` with 4.0.27 and 3.6.23 shells downloaded from https://www.mongodb.com/try/download/community. The command just loads dependencies and then loads all of the files under testcases to make sure there is no syntax errors on loading.

[evergreen run](https://spruce.mongodb.com/version/61ca129d0305b92df5e4751e/tasks)

bizarrely Array's forEach method works fine in the 4.0 shell but `for (const var of [])` doesn't?