### PR TITLE
PERF-3282 remove unsupported use of  in wildcard benchmarks

### DIFF
--- a/testcases/wildcard_index_query.js
+++ b/testcases/wildcard_index_query.js
@@ -240,7 +240,7 @@ if ((typeof tests === "undefined" ? "undefined" : typeof(tests)) != "object") {
             var rangeStart = Random.randInt(maxValue - 10);
 
             query[fieldList[i]] = {$gte: rangeStart, $lte: (rangeStart + 10)};
-            list.push({op: "find", query: {$query: query, $orderby: sort}});
+            list.push({op: "find", query, sort});
         }
         return list;
     }


### PR DESCRIPTION
I tested this locally and the error went away and it started reporting data. [here](https://spruce.mongodb.com/version/632206249ccd4e77c0d24dc7/tasks) is a patch build that will hopefully eventually finish. When I looked at the benchRun parser it had the option for specifying sort at the top level so I just used that instead.