### PR TITLE
PERF-3365 Extend index scan microbenchmarks

### DIFF
--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1135,8 +1135,7 @@ if (typeof(tests) !== "object") {
         query: {"e.a": {$gt: 1}}
     });
 
-    // Select ~1% from a single indexed field. This tests the simple lowKey and highKey range 
-    // IXSCAN plan.
+    // Select ~1% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS",
         tags: ["indexed"],
@@ -1144,8 +1143,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {"b": {$gt: 100, $lt: 109}}
     });
-    // Select ~99% from a single indexed field. This tests the simple lowKey and highKey range 
-    // IXSCAN plan.
+
+    // Select ~99% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_SimpleRange_LS",
         tags: ["indexed"],
@@ -1153,7 +1152,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {"b": {$gt: 1, $lt: 999}}
     });
-    // Select ~90% from two indexed field. This tests the optimized single intervals IXSCAN plan.
+
+    // Select ~90% from two indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS",
         tags: ["indexed"],
@@ -1161,8 +1161,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1, "h": 1}],
         query: {"b": {"$in": largeArrayRandom}, "h": {$gt: 100}}
     });
-    // Select ~99% from a single indexed field. This tests the generic IXSCAN plan with index 
-    // bounds.
+
+    // Select ~99% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_LS",
         tags: ["indexed"],
@@ -1170,7 +1170,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {$or: [{"b": {$gt: 99}}, {"b": {$lt: 9}}, {"b": {"$in": largeArrayRandom}}]}
     });
-    // Select ~99% from two indexed field. This tests the generic IXSCAN plan with index bounds.
+
+    // Select ~99% from two indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_LS",
         tags: ["indexed"],
@@ -1178,7 +1179,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1}],
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
     });
-    // Select ~99% from three indexed field. This tests the generic IXSCAN plan with index bounds.
+
+    // Select ~99% from three indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS",
         tags: ["indexed"],
@@ -1186,7 +1188,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1, "a": 1}],
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
     });
-    // Select ~99% from two indexed field. This tests the generic IXSCAN plan with index bounds.
+
+    // Select ~99% from two indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS",
         tags: ["indexed"],
@@ -1194,7 +1197,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1}],
         query: {"h": {$gt: 1}, "b": {$lt: 100}}
     });
-    // Select ~99% from three indexed field. This tests the generic IXSCAN plan with index bounds.
+
+    // Select ~99% from three indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_Range_LS",
         tags: ["indexed"],
@@ -1202,12 +1206,13 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1, "a": 1}],
         query: {"h": {$gt: 1}, "b": {$lt: 100}, "a": {$gt: 1}}
     });
-    // Select ~99% from five indexed field. This tests the generic IXSCAN plan with index bounds.
+
+    // Select ~99% from five indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_FiveFields_Range_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
-        indexes: [{"h": 1, "b": 1, "a": 1, "d": 1, "e.a": 1}],
-        query: {"h": {$gt: 1}, "b": {$lt: 100}, "a": {$gt: 1}, "d": {$gt : 10}, "e.a": {$gt: 1}}
+        indexes: [{"h": 1, "b": 1, "e.b": 1, "d": 1, "e.h": 1}],
+        query: {"h": {$gt: 1}, "b": {$lt: 100}, "e.b": {$gt: 1}, "d": {$gt : 10}, "e.h": {$gt: 1}}
     });
 }());

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1071,8 +1071,8 @@ if (typeof(tests) !== "object") {
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_MultiFields_LL",
         docGenerator: largeDoc,
-        indexes: [{"a": 1, "b": 1}],
-        query: {"a": {$gt: 1}, "b": {$lt: 900}}
+        indexes: [{"h": 1, "b": 1}],
+        query: {"h": {$gt: 1}, "b": {$lt: 999}}
     });
     addTestCaseWithLargeDatasetAndIndexes({
         name: "PointQuery_MultipleIndexes_LL", 

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1106,7 +1106,13 @@ if (typeof(tests) !== "object") {
         name: "RangeQuery_SingleIndex_MultiFields_LL",
         docGenerator: largeDoc,
         indexes: [{"h": 1, "b": 1}],
-        query: {"h": {$gt: 1}, "b": {$lt: 999}}
+        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_MultiFields2_LL",
+        docGenerator: largeDoc,
+        indexes: [{"h": 1, "b": 1, "a": 1}],
+        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
     });
     addTestCaseWithLargeDatasetAndIndexes({
         name: "PointQuery_MultipleIndexes_LL", 

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1103,18 +1103,6 @@ if (typeof(tests) !== "object") {
         query: {"a": {$gt: 1}}
     });
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_MultiFields_LL",
-        docGenerator: largeDoc,
-        indexes: [{"h": 1, "b": 1}],
-        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
-    });
-    addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_MultiFields2_LL",
-        docGenerator: largeDoc,
-        indexes: [{"h": 1, "b": 1, "a": 1}],
-        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
-    });
-    addTestCaseWithLargeDatasetAndIndexes({
         name: "PointQuery_MultipleIndexes_LL", 
         docGenerator: largeDoc,
         indexes: [{"a":1}, {"b":1}, {"a":1, "b":1}],
@@ -1122,7 +1110,15 @@ if (typeof(tests) !== "object") {
     });
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_MultipleIndexes_LowSelectivityMatch_LL", 
+        tags: ["indexed"],
         docGenerator: largeDoc,
+        indexes: [{"a":1}, {"b":1}, {"a":1, "b":1}],
+        query: {"a": {$gt: 1}, "b": {$lt: 900}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_MultipleIndexes_LowSelectivityMatch_LS", 
+        tags: ["indexed"],
+        docGenerator: smallDoc,
         indexes: [{"a":1}, {"b":1}, {"a":1, "b":1}],
         query: {"a": {$gt: 1}, "b": {$lt: 900}}
     });
@@ -1137,5 +1133,55 @@ if (typeof(tests) !== "object") {
         docGenerator: largeDoc,
         indexes: [{"e.a":1}],
         query: {"e.a": {$gt: 1}}
+    });
+
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"b": 1}],
+        query: {"b": {$gt: 100, $lt: 109}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_SimpleRange_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"b": 1}],
+        query: {"b": {$gt: 1, $lt: 999}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"b": 1, "h": 1}],
+        query: {"b": {"$in": largeArrayRandom}, "h": {$gt: 100}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"b": 1}],
+        query: {$or: [{"b": {$gt: 99}}, {"b": {$lt: 9}}, {"b": {"$in": largeArrayRandom}}]}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"h": 1, "b": 1}],
+        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"h": 1, "b": 1, "a": 1}],
+        query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"h": 1, "b": 1}],
+        query: {"h": {$gt: 1}, "b": {$lt: 100}}
     });
 }());

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1135,6 +1135,8 @@ if (typeof(tests) !== "object") {
         query: {"e.a": {$gt: 1}}
     });
 
+    // Select ~1% from a single indexed field. This tests the simple lowKey and highKey range 
+    // IXSCAN plan.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS",
         tags: ["indexed"],
@@ -1142,6 +1144,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {"b": {$gt: 100, $lt: 109}}
     });
+    // Select ~99% from a single indexed field. This tests the simple lowKey and highKey range 
+    // IXSCAN plan.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_SimpleRange_LS",
         tags: ["indexed"],
@@ -1149,6 +1153,7 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {"b": {$gt: 1, $lt: 999}}
     });
+    // Select ~90% from two indexed field. This tests the optimized single intervals IXSCAN plan.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS",
         tags: ["indexed"],
@@ -1156,6 +1161,8 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1, "h": 1}],
         query: {"b": {"$in": largeArrayRandom}, "h": {$gt: 100}}
     });
+    // Select ~99% from a single indexed field. This tests the generic IXSCAN plan with index 
+    // bounds.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_LS",
         tags: ["indexed"],
@@ -1163,6 +1170,7 @@ if (typeof(tests) !== "object") {
         indexes: [{"b": 1}],
         query: {$or: [{"b": {$gt: 99}}, {"b": {$lt: 9}}, {"b": {"$in": largeArrayRandom}}]}
     });
+    // Select ~99% from two indexed field. This tests the generic IXSCAN plan with index bounds.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_LS",
         tags: ["indexed"],
@@ -1170,6 +1178,7 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1}],
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
     });
+    // Select ~99% from three indexed field. This tests the generic IXSCAN plan with index bounds.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS",
         tags: ["indexed"],
@@ -1177,11 +1186,28 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1, "a": 1}],
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
     });
+    // Select ~99% from two indexed field. This tests the generic IXSCAN plan with index bounds.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1}],
         query: {"h": {$gt: 1}, "b": {$lt: 100}}
+    });
+    // Select ~99% from three indexed field. This tests the generic IXSCAN plan with index bounds.
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_Range_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"h": 1, "b": 1, "a": 1}],
+        query: {"h": {$gt: 1}, "b": {$lt: 100}, "a": {$gt: 1}}
+    });
+    // Select ~99% from five indexed field. This tests the generic IXSCAN plan with index bounds.
+    addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_GenericPlan_FiveFields_Range_LS",
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"h": 1, "b": 1, "a": 1, "d": 1, "e.a": 1}],
+        query: {"h": {$gt: 1}, "b": {$lt: 100}, "a": {$gt: 1}, "d": {$gt : 10}, "e.a": {$gt: 1}}
     });
 }());

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1148,7 +1148,7 @@ if (typeof(tests) !== "object") {
 
     // Select ~90% with two range predicates on two indexed fields of a compound index.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS",
+        name: "RangeQuery_CompoundIndex_SingleIntervals_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"b": 1, "h": 1}],
@@ -1157,7 +1157,7 @@ if (typeof(tests) !== "object") {
 
     // Select ~99% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_LS",
+        name: "RangeQuery_SingleFieldIndex_ComplexBounds_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"b": 1}],
@@ -1167,7 +1167,7 @@ if (typeof(tests) !== "object") {
     // Select ~99% from two indexed fields of a compound index. There is a range predicate on the
     // leading field and a union of point predicates on the trailing field.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_LS",
+        name: "RangeQuery_CompoundIndex_ComplexBounds_TwoFields_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1}],
@@ -1177,7 +1177,7 @@ if (typeof(tests) !== "object") {
     // Select ~99% from three indexed fields of a compound index. There is a range predicate on 
     // the leading field and unions of point intervals on the trailing fields.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS",
+        name: "RangeQuery_CompoundIndex_ComplexBounds_ThreeFields_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1, "a": 1}],
@@ -1186,7 +1186,7 @@ if (typeof(tests) !== "object") {
 
     // Select ~99% from two indexed fields of a compound index with range predicates on both fields.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS",
+        name: "RangeQuery_CompoundIndex_ComplexBounds_TwoFields_Range_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1}],
@@ -1196,7 +1196,7 @@ if (typeof(tests) !== "object") {
     // Select ~99% from three indexed fields of a compound index with range predicates on all
     // three fields.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_Range_LS",
+        name: "RangeQuery_CompoundIndex_ComplexBounds_ThreeFields_Range_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1, "a": 1}],
@@ -1205,7 +1205,7 @@ if (typeof(tests) !== "object") {
 
     // Select ~99% from five indexed fields of a compound index.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_GenericPlan_FiveFields_Range_LS",
+        name: "RangeQuery_CompoundIndex_ComplexBounds_FiveFields_Range_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"h": 1, "b": 1, "e.b": 1, "d": 1, "e.h": 1}],

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1116,13 +1116,6 @@ if (typeof(tests) !== "object") {
         query: {"a": {$gt: 1}, "b": {$lt: 900}}
     });
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_MultipleIndexes_LowSelectivityMatch_LS", 
-        tags: ["indexed"],
-        docGenerator: smallDoc,
-        indexes: [{"a":1}, {"b":1}, {"a":1, "b":1}],
-        query: {"a": {$gt: 1}, "b": {$lt: 900}}
-    });
-    addTestCaseWithLargeDatasetAndIndexes({
         name: "PointQuerySubField_SingleIndex_LL", 
         docGenerator: largeDoc,
         indexes: [{"e.a":1}],
@@ -1137,7 +1130,7 @@ if (typeof(tests) !== "object") {
 
     // Select ~1% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS",
+        name: "RangeQuery_SingleIndex_SimpleRange_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"b": 1}],
@@ -1146,14 +1139,14 @@ if (typeof(tests) !== "object") {
 
     // Select ~99% from a single indexed field.
     addTestCaseWithLargeDatasetAndIndexes({
-        name: "RangeQuery_SingleIndex_SimpleRange_LS",
+        name: "RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS",
         tags: ["indexed"],
         docGenerator: smallDoc,
         indexes: [{"b": 1}],
         query: {"b": {$gt: 1, $lt: 999}}
     });
 
-    // Select ~90% from two indexed field.
+    // Select ~90% with two range predicates on two indexed fields of a compound index.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS",
         tags: ["indexed"],
@@ -1171,7 +1164,8 @@ if (typeof(tests) !== "object") {
         query: {$or: [{"b": {$gt: 99}}, {"b": {$lt: 9}}, {"b": {"$in": largeArrayRandom}}]}
     });
 
-    // Select ~99% from two indexed field.
+    // Select ~99% from two indexed fields of a compound index. There is a range predicate on the
+    // leading field and a union of point predicates on the trailing field.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_LS",
         tags: ["indexed"],
@@ -1180,7 +1174,8 @@ if (typeof(tests) !== "object") {
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}}
     });
 
-    // Select ~99% from three indexed field.
+    // Select ~99% from three indexed fields of a compound index. There is a range predicate on 
+    // the leading field and unions of point intervals on the trailing fields.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS",
         tags: ["indexed"],
@@ -1189,7 +1184,7 @@ if (typeof(tests) !== "object") {
         query: {"h": {$gt: 1}, "b": {"$in": largeArrayRandom}, "a": {"$in": largeArrayRandom}}
     });
 
-    // Select ~99% from two indexed field.
+    // Select ~99% from two indexed fields of a compound index with range predicates on both fields.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS",
         tags: ["indexed"],
@@ -1198,7 +1193,8 @@ if (typeof(tests) !== "object") {
         query: {"h": {$gt: 1}, "b": {$lt: 100}}
     });
 
-    // Select ~99% from three indexed field.
+    // Select ~99% from three indexed fields of a compound index with range predicates on all
+    // three fields.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_ThreeFields_Range_LS",
         tags: ["indexed"],
@@ -1207,7 +1203,7 @@ if (typeof(tests) !== "object") {
         query: {"h": {$gt: 1}, "b": {$lt: 100}, "a": {$gt: 1}}
     });
 
-    // Select ~99% from five indexed field.
+    // Select ~99% from five indexed fields of a compound index.
     addTestCaseWithLargeDatasetAndIndexes({
         name: "RangeQuery_SingleIndex_GenericPlan_FiveFields_Range_LS",
         tags: ["indexed"],

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -1069,6 +1069,12 @@ if (typeof(tests) !== "object") {
         query: {"a": {$gt: 1}}
     });
     addTestCaseWithLargeDatasetAndIndexes({
+        name: "RangeQuery_SingleIndex_MultiFields_LL",
+        docGenerator: largeDoc,
+        indexes: [{"a": 1, "b": 1}],
+        query: {"a": {$gt: 1}, "b": {$lt: 900}}
+    });
+    addTestCaseWithLargeDatasetAndIndexes({
         name: "PointQuery_MultipleIndexes_LL", 
         docGenerator: largeDoc,
         indexes: [{"a":1}, {"b":1}, {"a":1, "b":1}],


### PR DESCRIPTION
[evergreen perf patch](https://spruce.mongodb.com/version/633b653aa4cf47053a6d24df/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (base)
[evergreen perf patch](https://spruce.mongodb.com/version/633b63d13627e075845e4368/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (with https://github.com/10gen/mongo/pull/7252)


variant | test | thread_level | measurement | value | value_base | percent_base_diff
-- | -- | -- | -- | -- | -- | --
SBE | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LL | 4 | ops_per_sec | 14.57 | 13.72 | 6.18%
SBE | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LL | 1 | ops_per_sec | 3.82 | 3.66 | 4.29%
Classic | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LL | 4 | ops_per_sec | 16.84 | 14.97 | 12.47%
Classic | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LL | 1 | ops_per_sec | 4.41 | 3.96 | 11.32%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LS | 4 | ops_per_sec | 14.58 | 13.92 | 4.71%
SBE | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LS | 1 | ops_per_sec | 3.82 | 3.66 | 4.20%
Classic | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LS | 4 | ops_per_sec | 16.77 | 14.87 | 12.76%
Classic | Queries.RangeQuery_MultipleIndexes_LowSelectivityMatch_LS | 1 | ops_per_sec | 4.44 | 3.95 | 12.27%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_LS | 4 | ops_per_sec | 11.65 | 10.89 | 6.97%
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_LS | 1 | ops_per_sec | 3.14 | 2.97 | 5.41%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_LS | 4 | ops_per_sec | 13.29 | 11.98 | 10.97%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_LS | 1 | ops_per_sec | 3.61 | 3.30 | 9.54%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS | 4 | ops_per_sec | 10.41 | 7.70 | 35.25%
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS | 1 | ops_per_sec | 2.74 | 2.08 | 32.02%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS | 4 | ops_per_sec | 11.26 | 10.73 | 4.86%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_ThreeFields_LS | 1 | ops_per_sec | 2.93 | 2.71 | 8.32%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_LS | 4 | ops_per_sec | 9.73 | 8.15 | 19.39%
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_LS | 1 | ops_per_sec | 2.59 | 2.17 | 19.40%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_LS | 4 | ops_per_sec | 10.66 | 9.87 | 7.98%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_LS | 1 | ops_per_sec | 2.86 | 2.64 | 8.30%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS | 4 | ops_per_sec | 16.76 | 9.79 | 71.14%
SBE | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS | 1 | ops_per_sec | 4.30 | 2.64 | 62.89%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS | 4 | ops_per_sec | 17.23 | 15.76 | 9.34%
Classic | Queries.RangeQuery_SingleIndex_GenericPlan_TwoFields_Range_LS | 1 | ops_per_sec | 4.36 | 4.03 | 8.08%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS | 4 | ops_per_sec | 21.34 | 22.49 | -5.14%
SBE | Queries.RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS | 1 | ops_per_sec | 5.67 | 5.94 | -4.52%
Classic | Queries.RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS | 4 | ops_per_sec | 20.39 | 18.40 | 10.84%
Classic | Queries.RangeQuery_SingleIndex_MultiFields_SingleIntervals_LS | 1 | ops_per_sec | 5.47 | 4.91 | 11.35%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_SimpleRange_LS | 4 | ops_per_sec | 13.82 | 14.18 | -2.55%
SBE | Queries.RangeQuery_SingleIndex_SimpleRange_LS | 1 | ops_per_sec | 3.70 | 3.84 | -3.58%
Classic | Queries.RangeQuery_SingleIndex_SimpleRange_LS | 4 | ops_per_sec | 14.06 | 12.84 | 9.54%
Classic | Queries.RangeQuery_SingleIndex_SimpleRange_LS | 1 | ops_per_sec | 3.83 | 3.39 | 12.81%
  |   |   |   |   |   |  
SBE | Queries.RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS | 4 | ops_per_sec | 1,761.92 | 1,774.67 | -0.72%
SBE | Queries.RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS | 1 | ops_per_sec | 444.59 | 447.13 | -0.57%
Classic | Queries.RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS | 4 | ops_per_sec | 1,793.84 | 1,567.02 | 14.47%
Classic | Queries.RangeQuery_SingleIndex_SimpleRange_LowSelectivityMatch_LS | 1 | ops_per_sec | 458.40 | 396.62 | 15.58%

