### PR TITLE
Update python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pymongo==2.7.2
-bottle==0.11.6
-argparse==1.2.1
+pymongo==4.3.3
+bottle==0.12.23
+argparse==1.4.0
 requests>=2.4.3
 psutil>=2.1.3
 ordereddict>=1.1


### PR DESCRIPTION
To fix the issue `error in pymongo setup command: use_2to3 is invalid` when install python requirements

Refer to the [changelog](https://setuptools.pypa.io/en/latest/history.html#v58-0-0) lib2to3 has been removed in [Python 3.10](https://github.com/pypa/setuptools/issues/2086), I've just updated the requirement version to latest and it works.

Please check 👀 