### PR TITLE
SERVER-72240 Fixed Prototype Pollution in lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -703,7 +703,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "integrity": "sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==",
       "dev": true
     },
     "lru-cache": {


### PR DESCRIPTION
### Update 👾 Describe The Sumarry:
The Project of `mongodb/mongo-perf` used lodash before 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep allows a malicious user to modify the prototype of Object via `{constructor: {prototype: {...}}}` causing the addition or modification of an existing property that will exist on all objects.

**PoCs By Defcon:**
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload. Following is an example of how this vulnerability will impact a JavaScript application:
```js
const mergeFn = require('lodash').defaultsDeep;
const payload = '{"constructor": {"prototype": {"a0": true}}}'

function check() {
    mergeFn({}, JSON.parse(payload));
    if (({})[`a0`] === true) {
        console.log(`Vulnerable to Prototype Pollution via ${payload}`);
    }
  }

check();
```
Prototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as __proto__, constructor and prototype. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

The logic of a vulnerable recursive merge function follows the following high-level model:
```go
merge (target, source)
foreach property of source

if property exists and is an object on both the target and the source merge(target[property], source[property]) else target[property] = source[property]
```
### 🥷 According CVeScores:
CVE-2019-10744
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H`
