### PR TITLE
PERF-3797 Add CWI intersection performance tests

### DIFF
--- a/testcases/compound_wildcard_index_insert.js
+++ b/testcases/compound_wildcard_index_insert.js
@@ -1,0 +1,106 @@
+if ( typeof(tests) != "object" ) {
+    tests = [];
+}
+
+(function () {
+    'use strict';
+
+    // Setting random seed is required for smallDoc for it uses Random.
+    Random.setRandomSeed(5147);
+
+    const namePrefix = '[CWI.insert]';
+
+    // Base perfomance test cases which will be used to generate performance test cases.
+    const baseCases = [
+        {
+            name: "Compound Regular Index with 2 fields",
+            indexes: [{keyPattern: {'a': 1, 'b': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Wildcard Index with 2 fields",
+            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'b': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Regular Index of with fields, one of which is multikey",
+            indexes: [{keyPattern: {'a': 1, 'e.f': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Wildcard index with 2 fields, one of which is multikey",
+            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'e.f': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Multiple Compound Regular Indexes with 2 fields",
+            indexes: [
+                {keyPattern: {'a': 1, 'e.a': 1}},
+                {keyPattern: {'a': 1, 'e.b': 1}},
+                {keyPattern: {'a': 1, 'e.b': 1}},
+                {keyPattern: {'a': 1, 'e.g': 1}}, 
+                {keyPattern: {'a': 1, 'e.h': 1}}
+            ],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Wildcard Index with 2 fields and multiple fields in the projection",
+            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'e.a': 1, 'e.b': 1, 'e.c': 1, 'e.g': 1, 'e.h': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Regular Index with 5 fields",
+            indexes: [{keyPattern: {'a': 1, 'b': 1, 'c': 1, 'h': 1, 'i': 1}}],
+            documentGenerator: smallDoc,
+        },
+        {
+            name: "Compound Wildcard Index with 5 fields",
+            indexes: [{keyPattern: {'a': 1, '$**': 1, 'c': 1, 'h': 1, 'i': 1}, wildcardProjection: {'b': 1}}],
+            documentGenerator: smallDoc,
+        },
+    ];
+
+    // Generate perfomance test cases for different document numbers to be inserted. They will be used to create benchmark test cases.
+    const numberOfDocumentsList = [1, 100, 1000];
+    const cases = [];
+    for (let baseCase of baseCases) {
+        for (let numberOfDocuments of numberOfDocumentsList) {
+            const perfCase = Object.assign({numberOfDocuments}, baseCase);
+            perfCase.name = `${namePrefix} ${baseCase.name}. Inserting batches of ${numberOfDocuments} ${ numberOfDocuments == 1 ? "doc": "docs" }.`;
+            cases.push(perfCase);
+        }
+    }
+
+    // Returns setup function for the given perfomance test case.
+    function getSetupFunction(perfCase) {
+        return function(collection) {
+            collection.drop();
+            for (let indexSpec of perfCase.indexes) {
+                const indexOptions = {};
+                if (indexSpec.wildcardProjection) {
+                    indexOptions.wildcardProjection = indexSpec.wildcardProjection;
+                }
+                assert.commandWorked(collection.createIndex(indexSpec.keyPattern, indexOptions));
+            }
+        }
+    }
+
+    // Generates documents list for the given perfomance test case.
+    function generateDocuments(perfCase) {
+        const documents = [];
+        for (let i = 0; i < perfCase.numberOfDocuments; ++i) {
+            documents.push(perfCase.documentGenerator(i));
+        }
+        return documents;
+    }
+
+    // Create test cases for the benchmark.
+    for (let perfCase of cases) {
+        tests.push({
+            name: perfCase.name,
+            tags: ["insert"],
+            pre: getSetupFunction(perfCase),
+            ops: [{'op': 'insert', 'doc': generateDocuments(perfCase)}]
+        });
+    }
+})();

--- a/testcases/compound_wildcard_index_insert.js
+++ b/testcases/compound_wildcard_index_insert.js
@@ -105,7 +105,7 @@ function generateDocuments(perfCase) {
 for (let perfCase of cases) {
     tests.push({
         name: perfCase.name,
-        tags: ["insert"],
+        tags: ["compound-wildcard-insert"],
         pre: getSetupFunction(perfCase),
         ops: [{'op': 'insert', 'doc': generateDocuments(perfCase)}]
     });

--- a/testcases/compound_wildcard_index_insert.js
+++ b/testcases/compound_wildcard_index_insert.js
@@ -1,106 +1,113 @@
-if ( typeof(tests) != "object" ) {
+if (typeof (tests) != "object") {
     tests = [];
 }
 
-(function () {
-    'use strict';
+(function() {
+'use strict';
 
-    // Setting random seed is required for smallDoc for it uses Random.
-    Random.setRandomSeed(5147);
+// Setting random seed is required for smallDoc for it uses Random.
+Random.setRandomSeed(5147);
 
-    const namePrefix = '[CWI.insert]';
+const namePrefix = '[CWI.insert]';
 
-    // Base perfomance test cases which will be used to generate performance test cases.
-    const baseCases = [
-        {
-            name: "Compound Regular Index with 2 fields",
-            indexes: [{keyPattern: {'a': 1, 'b': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Wildcard Index with 2 fields",
-            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'b': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Regular Index of with fields, one of which is multikey",
-            indexes: [{keyPattern: {'a': 1, 'e.f': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Wildcard index with 2 fields, one of which is multikey",
-            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'e.f': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Multiple Compound Regular Indexes with 2 fields",
-            indexes: [
-                {keyPattern: {'a': 1, 'e.a': 1}},
-                {keyPattern: {'a': 1, 'e.b': 1}},
-                {keyPattern: {'a': 1, 'e.b': 1}},
-                {keyPattern: {'a': 1, 'e.g': 1}}, 
-                {keyPattern: {'a': 1, 'e.h': 1}}
-            ],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Wildcard Index with 2 fields and multiple fields in the projection",
-            indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'e.a': 1, 'e.b': 1, 'e.c': 1, 'e.g': 1, 'e.h': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Regular Index with 5 fields",
-            indexes: [{keyPattern: {'a': 1, 'b': 1, 'c': 1, 'h': 1, 'i': 1}}],
-            documentGenerator: smallDoc,
-        },
-        {
-            name: "Compound Wildcard Index with 5 fields",
-            indexes: [{keyPattern: {'a': 1, '$**': 1, 'c': 1, 'h': 1, 'i': 1}, wildcardProjection: {'b': 1}}],
-            documentGenerator: smallDoc,
-        },
-    ];
+// Base perfomance test cases which will be used to generate performance test cases.
+const baseCases = [
+    {
+        name: "Compound Regular Index with 2 fields",
+        indexes: [{keyPattern: {'a': 1, 'b': 1}}],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Wildcard Index with 2 fields",
+        indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'b': 1}}],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Regular Index of with fields, one of which is multikey",
+        indexes: [{keyPattern: {'a': 1, 'e.f': 1}}],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Wildcard index with 2 fields, one of which is multikey",
+        indexes: [{keyPattern: {'a': 1, '$**': 1}, wildcardProjection: {'e.f': 1}}],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Multiple Compound Regular Indexes with 2 fields",
+        indexes: [
+            {keyPattern: {'a': 1, 'e.a': 1}},
+            {keyPattern: {'a': 1, 'e.b': 1}},
+            {keyPattern: {'a': 1, 'e.b': 1}},
+            {keyPattern: {'a': 1, 'e.g': 1}},
+            {keyPattern: {'a': 1, 'e.h': 1}}
+        ],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Wildcard Index with 2 fields and multiple fields in the projection",
+        indexes: [{
+            keyPattern: {'a': 1, '$**': 1},
+            wildcardProjection: {'e.a': 1, 'e.b': 1, 'e.c': 1, 'e.g': 1, 'e.h': 1}
+        }],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Regular Index with 5 fields",
+        indexes: [{keyPattern: {'a': 1, 'b': 1, 'c': 1, 'h': 1, 'i': 1}}],
+        documentGenerator: smallDoc,
+    },
+    {
+        name: "Compound Wildcard Index with 5 fields",
+        indexes: [
+            {keyPattern: {'a': 1, '$**': 1, 'c': 1, 'h': 1, 'i': 1}, wildcardProjection: {'b': 1}}
+        ],
+        documentGenerator: smallDoc,
+    },
+];
 
-    // Generate perfomance test cases for different document numbers to be inserted. They will be used to create benchmark test cases.
-    const numberOfDocumentsList = [1, 100, 1000];
-    const cases = [];
-    for (let baseCase of baseCases) {
-        for (let numberOfDocuments of numberOfDocumentsList) {
-            const perfCase = Object.assign({numberOfDocuments}, baseCase);
-            perfCase.name = `${namePrefix} ${baseCase.name}. Inserting batches of ${numberOfDocuments} ${ numberOfDocuments == 1 ? "doc": "docs" }.`;
-            cases.push(perfCase);
-        }
+// Generate perfomance test cases for different document numbers to be inserted. They will be used
+// to create benchmark test cases.
+const numberOfDocumentsList = [1, 100, 1000];
+const cases = [];
+for (let baseCase of baseCases) {
+    for (let numberOfDocuments of numberOfDocumentsList) {
+        const perfCase = Object.assign({numberOfDocuments}, baseCase);
+        perfCase.name = `${namePrefix} ${baseCase.name}. Inserting batches of ${
+            numberOfDocuments} ${numberOfDocuments == 1 ? "doc" : "docs"}.`;
+        cases.push(perfCase);
     }
+}
 
-    // Returns setup function for the given perfomance test case.
-    function getSetupFunction(perfCase) {
-        return function(collection) {
-            collection.drop();
-            for (let indexSpec of perfCase.indexes) {
-                const indexOptions = {};
-                if (indexSpec.wildcardProjection) {
-                    indexOptions.wildcardProjection = indexSpec.wildcardProjection;
-                }
-                assert.commandWorked(collection.createIndex(indexSpec.keyPattern, indexOptions));
+// Returns setup function for the given perfomance test case.
+function getSetupFunction(perfCase) {
+    return function(collection) {
+        collection.drop();
+        for (let indexSpec of perfCase.indexes) {
+            const indexOptions = {};
+            if (indexSpec.wildcardProjection) {
+                indexOptions.wildcardProjection = indexSpec.wildcardProjection;
             }
+            assert.commandWorked(collection.createIndex(indexSpec.keyPattern, indexOptions));
         }
     }
+}
 
-    // Generates documents list for the given perfomance test case.
-    function generateDocuments(perfCase) {
-        const documents = [];
-        for (let i = 0; i < perfCase.numberOfDocuments; ++i) {
-            documents.push(perfCase.documentGenerator(i));
-        }
-        return documents;
+// Generates documents list for the given perfomance test case.
+function generateDocuments(perfCase) {
+    const documents = [];
+    for (let i = 0; i < perfCase.numberOfDocuments; ++i) {
+        documents.push(perfCase.documentGenerator(i));
     }
+    return documents;
+}
 
-    // Create test cases for the benchmark.
-    for (let perfCase of cases) {
-        tests.push({
-            name: perfCase.name,
-            tags: ["insert"],
-            pre: getSetupFunction(perfCase),
-            ops: [{'op': 'insert', 'doc': generateDocuments(perfCase)}]
-        });
-    }
+// Create test cases for the benchmark.
+for (let perfCase of cases) {
+    tests.push({
+        name: perfCase.name,
+        tags: ["insert"],
+        pre: getSetupFunction(perfCase),
+        ops: [{'op': 'insert', 'doc': generateDocuments(perfCase)}]
+    });
+}
 })();


### PR DESCRIPTION
Example results for `python benchrun.py -f testcases/compound_wildcard_index_insert.js  -t 1 2` run:

```
[CWI.insert] Compound Regular Index with 2 fields. Inserting batches of 1 doc.
1       6902.051443623284
2       13363.981237054299
[CWI.insert] Compound Regular Index with 2 fields. Inserting batches of 100 docs.
1       2834.467346848199
2       5171.561846858444
[CWI.insert] Compound Regular Index with 2 fields. Inserting batches of 1000 docs.
1       629.491045794724
2       1194.8517838129765
[CWI.insert] Compound Wildcard Index with 2 fields. Inserting batches of 1 doc.
1       7313.298467546089
2       13065.661304191573
[CWI.insert] Compound Wildcard Index with 2 fields. Inserting batches of 100 docs.
1       2772.96291187096
2       5249.832288417547
[CWI.insert] Compound Wildcard Index with 2 fields. Inserting batches of 1000 docs.
1       629.2657340420768
2       1159.9636439449318
[CWI.insert] Compound Regular Index of with fields, one of which is multikey. Inserting batches of 1 doc.
1       6250.823410590155
2       12780.312713266745
[CWI.insert] Compound Regular Index of with fields, one of which is multikey. Inserting batches of 100 docs.
1       2826.8607751076315
2       5066.412459864582
[CWI.insert] Compound Regular Index of with fields, one of which is multikey. Inserting batches of 1000 docs.
1       618.8734823507117
2       1111.5609937619085
[CWI.insert] Compound Wildcard index with 2 fields, one of which is multikey. Inserting batches of 1 doc.
1       6587.892648058149
2       12912.592771466798
[CWI.insert] Compound Wildcard index with 2 fields, one of which is multikey. Inserting batches of 100 docs.
1       2834.1054684680776
2       5114.502611322789
[CWI.insert] Compound Wildcard index with 2 fields, one of which is multikey. Inserting batches of 1000 docs.
1       620.5221301901008
2       1179.2438688313055
[CWI.insert] Multiple Compound Regular Indexes with 2 fields. Inserting batches of 1 doc.
1       7049.543731921811
2       12558.982360014033
[CWI.insert] Multiple Compound Regular Indexes with 2 fields. Inserting batches of 100 docs.
1       2825.129840816299
2       5231.800841342021
[CWI.insert] Multiple Compound Regular Indexes with 2 fields. Inserting batches of 1000 docs.
1       615.6372665225649
2       1155.1187109842615
[CWI.insert] Compound Wildcard Index with 2 fields and multiple fields in the projection. Inserting batches of 1 doc.
1       7329.074400961428
2       12910.624992254903
[CWI.insert] Compound Wildcard Index with 2 fields and multiple fields in the projection. Inserting batches of 100 docs.
1       2842.0081391594335
2       5270.966788971645
[CWI.insert] Compound Wildcard Index with 2 fields and multiple fields in the projection. Inserting batches of 1000 docs.
1       618.1733776397572
2       1122.264692173688
[CWI.insert] Compound Regular Index with 5 fields. Inserting batches of 1 doc.
1       7246.030557564288
2       12449.75520279028
[CWI.insert] Compound Regular Index with 5 fields. Inserting batches of 100 docs.
1       2761.79084162647
2       5039.366742298142
[CWI.insert] Compound Regular Index with 5 fields. Inserting batches of 1000 docs.
1       621.0236596622447
2       1140.1717653572882
[CWI.insert] Compound Wildcard Index with 5 fields. Inserting batches of 1 doc.
1       7308.386520980097
2       12755.666547594323
[CWI.insert] Compound Wildcard Index with 5 fields. Inserting batches of 100 docs.
1       2840.0310432226097
2       5280.814898222678
[CWI.insert] Compound Wildcard Index with 5 fields. Inserting batches of 1000 docs.
1       631.211047752375
2       1214.6926246094167
```