### PR TITLE
PERF-3800 Add CWI.query tests

### DIFF
--- a/testcases/compound_wildcard_index_query.js
+++ b/testcases/compound_wildcard_index_query.js
@@ -1,0 +1,129 @@
+if (typeof (tests) != "object") {
+    tests = [];
+}
+
+(function() {
+'use strict';
+
+// Setting random seed is required for smallDoc for it uses Random.
+Random.setRandomSeed(4921);
+
+const namePrefix = '[CWI.query]';
+
+const indexSpecs = [
+    {
+        description: "Regular. 3 fields.",
+        keyPattern: {'a': 1, 'e.h': -1, 'e.e': 1},
+        tags: ["core"],
+    },
+    {
+        description: "Wildcard. 3 fields. Wildcard Component on 0.",
+        keyPattern: {'$**': 1, 'e.h': -1, 'e.e': 1},
+        wildcardProjection: {'a': 1},
+        tags: ["core", "regression"],
+    },
+    {
+        description: "Wildcard. 3 fields. Wildcard Component on 1.",
+        keyPattern: {'a': 1, '$**': -1, 'e.e': 1},
+        wildcardProjection: {'e.h': 1},
+        tags: ["core", "regression"],
+    },
+];
+
+const queries = [
+    {
+        description: 'Point Query.',
+        query: {a: 5, 'e.h': 5, 'e.e': 5},
+    },
+    {
+        description: 'Range Query.',
+        query: {a: {$gt: 10}, 'e.h': {$lt: 10}, 'e.e': {$lt: 5}},
+    },
+    {
+        description: 'Point and Range Query.',
+        query: {a: 5, 'e.h': {$lt: 10}, 'e.e': {$lt: 5}},
+    },
+    {
+        description: 'Prefix query.',
+        query: {a: 5},
+    },
+];
+
+const numberOfDocumentsList = [1000, 100000];
+
+const perfCases = [];
+for (let indexSpec of indexSpecs) {
+    for (let query of queries) {
+        for (let numberOfDocuments of numberOfDocumentsList) {
+            perfCases.push({
+                name: `${namePrefix} ${indexSpec.description} ${
+                    query.description} Collection size ${numberOfDocuments} docs.`,
+                indexes: [indexSpec],
+                query: query.query,
+                tags: indexSpec.tags
+            });
+
+            perfCases.push({
+                name: `${namePrefix} ${indexSpec.description} ${
+                    query.description} With sort. Collection size ${numberOfDocuments} docs.`,
+                indexes: [indexSpec],
+                query: query.query,
+                sort: {a: 1, 'e.h': -1, 'e.e': 1},
+                tags: indexSpec.tags
+            });
+
+            perfCases.push({
+                name: `${namePrefix} ${indexSpec.description} ${
+                    query.description} Covered. Collection size ${numberOfDocuments} docs.`,
+                indexes: [indexSpec],
+                query: query.query,
+                filter: {_id: 0, a: 1},
+                tags: indexSpec.tags,
+            });
+        }
+    }
+}
+
+// Generates documents list for the given perfomance test case.
+function generateDocuments(perfCase) {
+    const documents = [];
+    for (let i = 0; i < perfCase.numberOfDocuments; ++i) {
+        documents.push(perfCase.documentGenerator(i));
+    }
+    return documents;
+}
+
+// Returns setup function for the given perfomance test case.
+function getSetupFunction(perfCase) {
+    return function(collection) {
+        collection.drop();
+        for (let indexSpec of perfCase.indexes) {
+            const indexOptions = {};
+            if (indexSpec.wildcardProjection) {
+                indexOptions.wildcardProjection = indexSpec.wildcardProjection;
+            }
+            assert.commandWorked(collection.createIndex(indexSpec.keyPattern, indexOptions));
+            const docs = generateDocuments(perfCase);
+            assert.commandWorked(collection.insertMany(docs));
+        }
+    }
+}
+
+// Create test cases for the benchmark.
+for (let perfCase of perfCases) {
+    const op = {'op': 'find', 'query': perfCase.query};
+    if (perfCase.sort !== undefined) {
+        op.sort = perfCase.sort;
+    }
+    if (perfCase.filter !== undefined) {
+        op.filter = perfCase.filter;
+    }
+
+    tests.push({
+        name: perfCase.name,
+        tags: ["compound-wildcard-query"].concat(perfCase.tags),
+        pre: getSetupFunction(perfCase),
+        ops: [op],
+    });
+}
+})();

--- a/testcases/compound_wildcard_index_query.js
+++ b/testcases/compound_wildcard_index_query.js
@@ -36,12 +36,27 @@ const queries = [
         query: {a: 5, 'e.h': 5, 'e.e': 5},
     },
     {
+        description: 'Point Query with sort.',
+        query: {a: 5, 'e.h': 5, 'e.e': 5},
+        sort: {a: 1, 'e.h': -1, 'e.e': 1},
+    },
+    {
+        description: 'Covered Point Query.',
+        query: {a: 5, 'e.h': 5, 'e.e': 5},
+        filter: {_id: 0, a: 1},
+    },
+    {
         description: 'Range Query.',
         query: {a: {$gt: 10}, 'e.h': {$lt: 10}, 'e.e': {$lt: 5}},
     },
     {
         description: 'Point and Range Query.',
         query: {a: 5, 'e.h': {$lt: 10}, 'e.e': {$lt: 5}},
+    },
+    {
+        description: 'ESR Query',
+        query: {a: 5, 'e.h': {$lt: 10}, 'e.e': {$lt: 5}},
+        sort: {a: 1, 'e.h': -1, 'e.e': 1},
     },
     {
         description: 'Prefix query.',
@@ -60,25 +75,9 @@ for (let indexSpec of indexSpecs) {
                     query.description} Collection size ${numberOfDocuments} docs.`,
                 indexes: [indexSpec],
                 query: query.query,
+                sort: query.sort,
+                filter: query.filter,
                 tags: indexSpec.tags
-            });
-
-            perfCases.push({
-                name: `${namePrefix} ${indexSpec.description} ${
-                    query.description} With sort. Collection size ${numberOfDocuments} docs.`,
-                indexes: [indexSpec],
-                query: query.query,
-                sort: {a: 1, 'e.h': -1, 'e.e': 1},
-                tags: indexSpec.tags
-            });
-
-            perfCases.push({
-                name: `${namePrefix} ${indexSpec.description} ${
-                    query.description} Covered. Collection size ${numberOfDocuments} docs.`,
-                indexes: [indexSpec],
-                query: query.query,
-                filter: {_id: 0, a: 1},
-                tags: indexSpec.tags,
             });
         }
     }


### PR DESCRIPTION
Command to run:
```
python benchrun.py -f testcases/compound_wildcard_index_query.js --readCmd --trialTime 1 -t 4 8
```

Some of the test results (too many tests to list all of them):
```
[CWI.query] Regular. 3 fields. Point Query. Collection size 1000 docs.
4       11042.0704081908
8       17324.696637905443
[CWI.query] Regular. 3 fields. Point Query. With sort. Collection size 1000 docs.
4       7792.836108539934
8       9717.905928672071
[CWI.query] Regular. 3 fields. Point Query. Covered. Collection size 1000 docs.
4       11862.041666583367
8       17643.578329172222
[CWI.query] Regular. 3 fields. Point Query. Collection size 100000 docs.
4       11463.941764615327
8       17339.561328190208
[CWI.query] Regular. 3 fields. Point Query. With sort. Collection size 100000 docs.
4       7730.47767056272
8       9635.97537395239
[CWI.query] Regular. 3 fields. Point Query. Covered. Collection size 100000 docs.
4       11303.478608556577
8       17496.81149222164
[CWI.query] Regular. 3 fields. Range Query. Collection size 1000 docs.
4       10357.67049373362
8       16595.94285862767
[CWI.query] Regular. 3 fields. Range Query. With sort. Collection size 1000 docs.
4       7647.426838750426
8       9597.341321625343
[CWI.query] Regular. 3 fields. Range Query. Covered. Collection size 1000 docs.
4       10264.479283605724
8       17078.957572947107
[CWI.query] Regular. 3 fields. Range Query. Collection size 100000 docs.
4       10552.705049045038
8       16519.072037705337
[CWI.query] Regular. 3 fields. Range Query. With sort. Collection size 100000 docs.
4       7246.876527255991
8       9507.650586096948
[CWI.query] Regular. 3 fields. Range Query. Covered. Collection size 100000 docs.
4       10921.855805915413
8       16966.651375092326
[CWI.query] Regular. 3 fields. Point and Range Query. Collection size 1000 docs.
4       10393.268816494878
8       16655.773355159934
[CWI.query] Regular. 3 fields. Point and Range Query. With sort. Collection size 1000 docs.
4       7440.6546576799155
8       9588.427945416797
[CWI.query] Regular. 3 fields. Point and Range Query. Covered. Collection size 1000 docs.
4       10720.090198689
8       17050.139061417878
[CWI.query] Regular. 3 fields. Point and Range Query. Collection size 100000 docs.
4       10655.428821035775
8       16525.852754591986
[CWI.query] Regular. 3 fields. Point and Range Query. With sort. Collection size 100000 docs.
4       7544.428076585588
8       9481.812124051794
[CWI.query] Regular. 3 fields. Point and Range Query. Covered. Collection size 100000 docs.
4       10894.805499882545
8       16862.08509396475
[CWI.query] Regular. 3 fields. Prefix query. Collection size 1000 docs.
4       11169.627409216168
8       17557.607463632383
[CWI.query] Regular. 3 fields. Prefix query. With sort. Collection size 1000 docs.
4       8578.624901300336
8       10680.384885576585
[CWI.query] Regular. 3 fields. Prefix query. Covered. Collection size 1000 docs.
4       12029.152251642588
8       17889.379124492967
```