### PR TITLE
PERF-3999 Add string collation tests with big collection and large in

### DIFF
--- a/testcases/simple_in_queries.js
+++ b/testcases/simple_in_queries.js
@@ -12,6 +12,10 @@ if (typeof(tests) !== "object") {
      * large collection.
      */
     function addStringInTestCases({name, collation, inArray}) {
+        const collectionOptions = {};
+        if (collation) {
+            collectionOptions.collation = collation;
+        }
         for (const [nameSuffix, size] of [["", 10], ["BigCollection", 10000]]) {
             addQueryTestCase({
                 name: name + nameSuffix,
@@ -19,7 +23,7 @@ if (typeof(tests) !== "object") {
                 // TODO (SERVER-5722): We cannot create a views passthrough because benchRun doesn't support
                 // sorting when running in read command mode.
                 createViewsPassthrough: false,
-                collectionOptions: {collation: collation},
+                collectionOptions: collectionOptions,
                 nDocs: size,
                 docs: function (i) {
                     return {x: i.toString()};


### PR DESCRIPTION
**Jira Ticket:** PERF-3999

**Whats Changed:**
For all StringUnindexed*InPred* tests added BigCollection variant with 10000 documents.
Added StringUnindexedLargeInPred* tests with $in array of 1000 elements.

**Patch testing results:**
https://spruce.mongodb.com/version/642e7f6f3627e002d796b7ee/tasks