### PR TITLE
SERVER-52958 Add more perf test for COUNT SCAN

### DIFF
--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -1699,6 +1699,41 @@ generateTestCase({
     addSkipStage: false,
 });
 
+generateTestCase({
+    name: "CountsIntIDRangeLarge",
+    tags: ["agg_query_comparison"],
+    nDocs: 4800,
+    docGenerator: function(i) {
+        return {_id: i};
+    },
+    pipeline: [{$match: {_id: {$gt: 10, $lt: 5000}}}, {$count: "n"}],
+    addSkipStage: false,
+});
+
+generateTestCase({
+    name: "CountsIntIdxRange",
+    tags: ["agg_query_comparison"],
+    nDocs: 4800,
+    docGenerator: function(i) {
+        return {_id: i, a : i};
+    },
+    indices: [{a: 1}],
+    pipeline: [{$match: {a: {$gt: 10, $lt: 100}}}, {$count: "n"}],
+    addSkipStage: false,
+});
+
+generateTestCase({
+    name: "CountsIntIdxRangeLarge",
+    tags: ["agg_query_comparison"],
+    nDocs: 4800,
+    docGenerator: function(i) {
+        return {_id: i, a : i};
+    },
+    indices: [{a: 1}],
+    pipeline: [{$match: {a: {$gt: 10, $lt: 5000}}}, {$count: "n"}],
+    addSkipStage: false,
+});
+
 //
 // Distinct operations expressed as aggregations.
 //


### PR DESCRIPTION
Thanks for submitting a PR to the Mongo-Perf repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-52958

**Whats Changed:**
Add more perf test for COUNT SCAN

**Patch testing results:**
[patch](https://spruce.mongodb.com/version/645dbca861837d14ab89e861/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=agg-query-comparison_read_commands)

**Workload Submission form:**
If applicable, only required if there is a new workload being added. Form can be found [here](https://docs.google.com/forms/d/1r0kOHvFUa7rJxVmX_wp9prxYU5K155yKyZ1y3d5yhZg/edit)

**Related PRs:**
https://github.com/10gen/mongo/pull/12502
https://github.com/10gen/mongo/pull/12629