### PR TITLE
SERVER-80273 Add tags to tie breaking tests

### DIFF
--- a/testcases/tie_breaking.js
+++ b/testcases/tie_breaking.js
@@ -123,7 +123,7 @@ for (let perfCase of perfCases) {
 
     tests.push({
         name: perfCase.name,
-        tags: ["tie-breaking"],
+        tags: ["tie-breaking", "core", "regression"],
         pre: getSetupFunction(perfCase),
         ops: [op],
     });


### PR DESCRIPTION
`etc/system_perf.yml` requires tags for secondary filters