### PR TITLE
PERF-4087 Added appropriate dataset sizes for lookup with disabled cache

### DIFF
--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -959,7 +959,9 @@ function basicUncorrelatedPipelineLookupPopulator(isView, disableCache, nDocs) {
         return {_id: val};
     }
 
-    const nDocs = nDocs ? nDocs : 50;
+    if (nDocs === undefined) {
+        nDocs = 50;
+    }
     if (disableCache === undefined) {
         disableCache = false;
     }

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -986,7 +986,7 @@ function basicUncorrelatedPipelineLookupPopulatorDisableCache(isView) {
  */
 function basicUncorrelatedPipelineLookupPopulatorDisableCacheLargeCollection(isView) {
     const disableCache = true;
-    const nDocs = 10000;
+    const nDocs = 1000;
     return basicUncorrelatedPipelineLookupPopulator(isView, disableCache, nDocs);
 }
 

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -738,7 +738,7 @@ for(let arrSize of [50, 250, 500]) {
 }
 
 
-    
+
 /**
  * These tests are paramterized on group size [100, 500], operator [$top, $bottom, $topN, $bottomN]
  * and 'n' [10, 50] if the operator accepts an n value.
@@ -2743,7 +2743,7 @@ generateTestCaseWithLargeDatasetAndIndexes({
  *
  * @param {Number} numElements: size of the array to generate and later sort.
  * @param {Boolean} isDescending: true if we're generating an array in descending order.
- * @param {String} variant: controls what type of data the array holds - either 'numbers', 
+ * @param {String} variant: controls what type of data the array holds - either 'numbers',
  * 'strings', or 'objects'.
  */
  function generateArrayForSortArray(numElements, isDescending, variant){

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -1139,12 +1139,12 @@ generateTestCase({
 
 function generateLookupUncorrelatedJoinTestCases(namePrefix, pipeline) {
     for (const disableCache of [false, true]) {
-        for (const nDocs of [50, 1000]) {
+        for (const nDocs of [50, 2000]) {
             let name = namePrefix;
             if (disableCache) {
                 name += ".NoCache";
             }
-            if (nDocs === 1000) {
+            if (nDocs !== 50) {
                 name += ".LargeCollection";
             }
             generateTestCase({

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -958,11 +958,11 @@ function basicUncorrelatedPipelineLookupPopulator(isView, disableCache, largeDat
     const nDocs = largeDataset ? 200 : 50;
     const paddingSize = largeDataset ? 1024*1024 : 16;
     const paddingStr = getStringOfLength(paddingSize);
-    function docGen(val) {
+    function localDocGen(val) {
         return {_id: val, padding: paddingStr};
     }
 
-    return basicMultiCollectionDataPopulator({isView, docGen, foreignCollsInfo: [{suffix: "_lookup", docGen: docGen}], nDocs, postFunction: (disableCache ? (function() {
+    return basicMultiCollectionDataPopulator({isView, localDocGen, foreignCollsInfo: [{suffix: "_lookup", docGen: localDocGen}], nDocs, postFunction: (disableCache ? (function() {
             setDocumentSourceLookupCacheSize(0);
         })
                                     : undefined) });


### PR DESCRIPTION
**Jira Ticket:** PERF-4087

**Whats Changed:**
Added Lookup.UncorrelatedJoin.NoCache.LargeCollection and Lookup.UncorrelatedPrefixJoin.NoCache.LargeCollection perf tests. 

**Patch testing results:**
https://spruce.mongodb.com/version/6530faf7d1fe079737233a97/tasks
