### PR TITLE
PERF-4977 Add MinAccTopField_LLR10 microbench variant w realistic fields

### DIFF
--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -2409,7 +2409,7 @@ generateTestCaseWithLargeDataset({
     pipeline: [{$group: {_id: "$order_month", res: {
         $min: "$quantity",
         $min: "$timestamp",
-        $min: "date_last_modified",
+        $min: "$date_last_modified",
         $min: "$shipping_speed",
         $min: "$browsing_time",
         $min: "$delivery_datetime",

--- a/testcases/pipelines.js
+++ b/testcases/pipelines.js
@@ -2403,6 +2403,22 @@ generateTestCaseWithLargeDataset({
     docGenerator: largeDoc,
     pipeline: [{$group: {_id: "$aa", res: {$min: "$cc"}}}]
 });
+generateTestCaseWithLargeDataset({
+    name: "Group.MinAccTopField_LLR10_10LargeFieldNames",
+    docGenerator: largeDocLargeFieldNames,
+    pipeline: [{$group: {_id: "$order_month", res: {
+        $min: "$quantity",
+        $min: "$timestamp",
+        $min: "date_last_modified",
+        $min: "$shipping_speed",
+        $min: "$browsing_time",
+        $min: "$delivery_datetime",
+        $min: "$tracking_number",
+        $min: "$date_created",
+        $min: "$customer",
+        $min: "$customer_comments"
+    }}}]
+});
 
 // $max
 generateTestCaseWithLargeDataset({

--- a/util/docGenerators.js
+++ b/util/docGenerators.js
@@ -65,7 +65,6 @@ const largeDoc = function (i) {
             h: Random.rand() * 1000,
             i: Random.rand() * 100000,
         },
-
         
         f: [Random.randInt(10), Random.randInt(10), Random.randInt(10)],
         g: Random.rand() * 10,
@@ -97,5 +96,63 @@ const largeDoc = function (i) {
         gg: Random.rand() * 10,
         hh: Random.rand() * 1000,
         ii: Random.rand() * 100000,
+    };
+}
+
+/**
+ * Variant of largeDoc() that has field name lengths and sometimes shared field name prefixes more
+ * typical of a production database. The doc contents are otherwise the same.
+ *
+ * @param {Number} i - the number to be used as _id
+ * @returns - a document of size ~8500 bytes (Object.bsonsize(largeDoc(N)))
+ */
+const largeDocLargeFieldNames = function (i) {
+    return {
+        _id: i,
+        customer: Random.randInt(10),
+        tracking_number: Random.randInt(1000),
+        date_created: Random.rand() * 100 + 1, // no zeros in this field
+        date_last_modified: i % 10000,
+        order_details: {
+            antelopes: Random.randInt(10),
+            brontosauri: Random.randInt(1000),
+            price: Random.rand() * 100 + 1,
+            widgets: { u: Random.randInt(100), v: Random.randInt(100) },
+            special_widgets: [Random.randInt(10), Random.randInt(10), Random.randInt(10)],
+            sale_price: Random.rand() * 10,
+            discount_code: Random.rand() * 1000,
+            promotion_code: Random.rand() * 100000,
+        },
+
+        order_ids: [Random.randInt(10), Random.randInt(10), Random.randInt(10)],
+        timestamp: Random.rand() * 10,
+        credit_card_number: Random.rand() * 1000,
+        phone_number: Random.rand() * 100000,
+
+        // Fields the queries won't be accessing but might need to copy/scan over.
+        customer_comments: [quotes, quotes, quotes, quotes, quotes],
+        favorite_products: { author: " Jane Austen", work: "Emma", quotes: quotes },
+        frequently_viewed_pages: { a: quotes[0] + i.toString(), b: quotes[2] + (i % 10).toString(), c: quotes[4] },
+        browsing_history: [quotes, quotes, quotes, quotes, quotes],
+
+        // Fields towards the end of the object some of the tests will be using.
+        order_month: Random.randInt(10),
+        browsing_time: Random.randInt(1000),
+        quantity: Random.rand() * 100 + 1,
+        returned_date: i % 10000,
+        tracking_details: {
+            carrier: Random.randInt(10),
+            carrier_phone: Random.randInt(1000),
+            shipping_price: Random.rand() * 100 + 1,
+            fulfillment_center: { u: Random.randInt(100), v: Random.randInt(100) },
+            location_history: [Random.randInt(10), Random.randInt(10), Random.randInt(10)],
+            back_order_date: Random.rand() * 10,
+            weight_kg: Random.rand() * 1000,
+            oversized: Random.rand() * 100000,
+        },
+        geography: [Random.randInt(10), Random.randInt(10), Random.randInt(10)],
+        ship_date: Random.rand() * 10,
+        shipping_speed: Random.rand() * 1000,
+        delivery_datetime: Random.rand() * 100000,
     };
 }


### PR DESCRIPTION
Add a variant of the Aggregation.Group.MinAccTopField_LLR10 microbenchmark called Aggregation.Group.MinAccTopField_LLR10_10LargeFieldNames that gives a more realistic production-type query, where the new test case differs from the original by:

1. Extracts more top-level fields from the documents (11 instead of 2)
2. Fields have more realistic name lengths, including some that share prefixes

This is related to [BF-30318](https://jira.mongodb.org/browse/BF-30318) and its fix ticket [SERVER-82972](https://jira.mongodb.org/browse/SERVER-82972).