### PR TITLE
SERVER-84402 Extend mongo-perf $in benchmarks for larger unindexed collection

### DIFF
--- a/testcases/simple_in_queries.js
+++ b/testcases/simple_in_queries.js
@@ -17,7 +17,7 @@ if (typeof(tests) !== "object") {
             collectionOptions.collation = collation;
         }
 
-        const collectionSizes = [["", 10], ["BigCollection", 10000], ["LargeCollection", 1e6]];
+        const collectionSizes = [["", 10], ["BigCollection", 10000], ["VeryBigCollection", 1e6]];
         for (const [nameSuffix, size] of collectionSizes) {
             addQueryTestCase({
                 name: name + nameSuffix,

--- a/testcases/simple_in_queries.js
+++ b/testcases/simple_in_queries.js
@@ -16,7 +16,9 @@ if (typeof(tests) !== "object") {
         if (collation) {
             collectionOptions.collation = collation;
         }
-        for (const [nameSuffix, size] of [["", 10], ["BigCollection", 10000]]) {
+
+        const collectionSizes = [["", 10], ["BigCollection", 10000], ["LargeCollection", 1e6]];
+        for (const [nameSuffix, size] of collectionSizes) {
             addQueryTestCase({
                 name: name + nameSuffix,
                 tags: ["regression", "collation"],


### PR DESCRIPTION
Thanks for submitting a PR to the Mongo-Perf repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-84402

**Whats Changed:**
Extend $in benchmarks to also run against a collection on 1M documents.

**Patch testing results:**
https://evergreen.mongodb.com/patch/658c3c5f850e617aecca3ce4