### PR TITLE
SERVER-84399 Extend existing projection tests to run with cardinalities

### DIFF
--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -361,7 +361,7 @@ if (typeof(tests) !== "object") {
      *
      * Test: Query for all documents (empty query) and return the three integer fields.
      */
-    for (const numOfDocs of [100, 10000, 1000000]) {
+    for (const numOfDocs of [10, 1000, 100000]) {
         addQueryTestCase({
             name: "FindProjectionThreeFields_Cardinality" + numOfDocs,
             tags: ["regression"],
@@ -394,7 +394,7 @@ if (typeof(tests) !== "object") {
      * collections with different cardinalities of 100, 10k, and 1M.
      */
     const addInclusionExclusionTestCase = function(name, docGenerator, inclusionSpec, exclusionSpec) {
-        for (const numOfDocs of [100, 10000, 1000000]) {
+        for (const numOfDocs of [10, 1000, 100000]) {
             for (const [prefix, testCase] of Object.entries({"FindInclusion.": inclusionSpec, "FindExclusion.": exclusionSpec})) {
                 addQueryTestCase({
                     name: prefix + name + "_Cardinality" + numOfDocs,
@@ -710,12 +710,12 @@ if (typeof(tests) !== "object") {
         name: "ProjectInclude_CollScan_LS",
         docGenerator: smallDoc,
         op: {op: "find", query: {}, filter: {a:1, b:1, c:1, d:1, f:1, g:1, h:1, i:1}}
-    }, [100, 100000, 1000000]);
+    }, [10, 1000, 100000]);
     addTestCaseWithMultipleDatasets({
         name: "ProjectInclude_CollScan_LL",
         docGenerator: largeDoc,
         op: {op: "find", query: {}, filter: {a:1, b:1, c:1, d:1, f:1, g:1, h:1, i:1}}
-    }, [100, 100000, 1000000]);
+    }, [10, 1000, 100000]);
     addTestCaseWithMultipleDatasets({
         name: "ProjectNoExpressions_CollScan_LS",
         docGenerator: smallDoc,
@@ -727,12 +727,12 @@ if (typeof(tests) !== "object") {
                 a2: "$a", b2: "$b", c2: "$c", d2: "$d",
             }
         }
-    }, [100, 100000, 1000000]);
+    }, [10, 1000, 100000]);
     addTestCaseWithMultipleDatasets({
         name: "ProjectExclude_CollScan_LL",
         docGenerator: largeDoc,
         op: {op: "find", query: {}, filter: {a:0, b:0, c:0, d:0, f:0, g:0, h:0, i:0}}
-    }, [100, 100000, 1000000]);
+    }, [10, 1000, 100000]);
     addTestCaseWithMultipleDatasets({
         name: "ProjectNoExpressions_CollScan_LL",
         docGenerator: largeDoc,
@@ -744,7 +744,7 @@ if (typeof(tests) !== "object") {
                 a2: "$a", b2: "$b", c2: "$c", d2: "$d",
             }
         }
-    }, [100, 100000, 1000000]);
+    }, [10, 1000, 100000]);
     addTestCaseWithLargeDataset({
         name: "ProjectNoExpressions_CollScan_LLR",
         docGenerator: smallDoc,

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -398,7 +398,7 @@ if (typeof(tests) !== "object") {
      * collections with different cardinalities of 100, 10k, and 100K.
      */
     const addInclusionExclusionTestCase = function(name, docGenerator, inclusionSpec, exclusionSpec) {
-        for (const testOpts of [{num: 100, name: ""}, {num: 10000, name: "Medium"}, {num: 100000, name: "Large"}]) {
+        for (const testOpts of [{num: 100, name: "Small"}, {num: 10000, name: ""}, {num: 100000, name: "Large"}]) {
             let tags = ["regression", "projection", ">=4.4.0"];
             if (testOpts.num >= 100000) {
                 tags.push("query_large_dataset");
@@ -553,16 +553,14 @@ if (typeof(tests) !== "object") {
      * cases depending on the options.
      * @param {query} - The query to benchmark with 'find' operation. Ignored if 'op' is defined.
      * @param {op} - The full definition of the op to be benchmarked.
-     * @param {Number} [options.nDocs = largeCollectionSize] - The number of documents to insert in
-     * the collection. Ignored, if 'generateData' is defined.
      * @param {Array} [options.names] - The names of tests to add.
      * @param {Array} [options.cardinalities] - The number of docs to insert for all tests.
      * options.cardinalities and options.names must have the same length.
      * @param {function} [options.docGenerator] - To be used with populatorGenerator. Ignored, if
      * 'generatedData' is defined.
      * @param {function} [options.generateData = populatorGenerator] - Uses 'docGenerator' to populate
-     * the collection with 'nDocs' documents. If the test is part of a suite that uses '--shareDataset'
-     * flag, the generator is run once (for the first test in the suite).
+     * the collection with corresponding 'cardinality'. If the test is part of a suite that uses
+     * '--shareDataset' flag, the generator is run once (for the first test in the suite).
      * @param {function} [options.pre=noop] - Any other setup, in addition to creating the data, that
      * the test might need. For example, creating indexes. The 'pre' fixture is run per test, so for
      * tests that share the dataset, the effects must be undone with 'post'.
@@ -570,8 +568,7 @@ if (typeof(tests) !== "object") {
      */
     function addTestCaseWithMultipleDatasets(options) {
         const largeCollectionSize = 100000;
-        const nDocs = options.nDocs || largeCollectionSize;
-        const cardinalities = options.cardinalities || [nDocs];
+        const cardinalities = options.cardinalities || [largeCollectionSize];
         assert.eq(options.names.length, cardinalities.length);
 
         let tags = options.tags || [];


### PR DESCRIPTION
Thanks for submitting a PR to the Mongo-Perf repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-84399

**Whats Changed:**
Extend existing projection tests to run with cardinalities

**Patch testing results:**
System failure patch (hit 6hr timed-out because the 1M cardinality is too big for COLLSCAN plan.): 
https://spruce.mongodb.com/version/659556f6306615d965b84f58/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
