### PR TITLE
SERVER-84724 Reduce collection size to stop mongo-perf $in benchmarks from timing out

### DIFF
--- a/testcases/simple_in_queries.js
+++ b/testcases/simple_in_queries.js
@@ -16,7 +16,7 @@ if (typeof(tests) !== "object") {
             collectionOptions.collation = collation;
         }
 
-        const collectionSizes = [["", 10], ["BigCollection", 10000], ["VeryBigCollection", 1e6]];
+        const collectionSizes = [["", 10], ["BigCollection", 10000], ["VeryBigCollection", 1e5]];
         for (const [nameSuffix, size] of collectionSizes) {
             addQueryTestCase({
                 name: name + nameSuffix,
@@ -159,7 +159,7 @@ if (typeof(tests) !== "object") {
         addQueryTestCase({
             name: name + "VeryBigCollection",
             tags: ["regression"],
-            nDocs: 1e6,
+            nDocs: 1e5,
             docs: function (i) {
                 return {x: 2 * Random.randInt(largeInArray.length * 10)};
             },
@@ -209,7 +209,7 @@ if (typeof(tests) !== "object") {
      * Adds three test cases for a $in query: One per a collection of 10, 10K, and 1M documents.
      */
     function addNonMatchingInTestCases({name, largeInArray}) {
-        for (const [nameSuffix, size] of [["", 10], ["BigCollection", 10000], ["VeryBigCollection", 1e6]]) {
+        for (const [nameSuffix, size] of [["", 10], ["BigCollection", 10000], ["VeryBigCollection", 1e5]]) {
             addQueryTestCase({
                 name: name + nameSuffix,
                 tags: ["regression"],


### PR DESCRIPTION
**Jira Ticket:** SERVER-84724

**Whats Changed:**
Reduce collection size to stop mongo-perf $in benchmarks from timing out. `query_read_commands` is currently timing out on Bonsai variants due to this. Once the $in regressions are fixed, we can try increasing the size back to 1M docs.

**Patch testing results:**
[patch 1](https://spruce.mongodb.com/version/659e8d36a4cf477e674c89a8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch 2](https://spruce.mongodb.com/version/659e96a3850e617197690046/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch 3](https://spruce.mongodb.com/version/659e9698d6d80a84c0823661/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch 4](https://spruce.mongodb.com/version/659e96881e2d17778ef0f450/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)