### PR TITLE
SERVER-83288 Add perf test case for compound index

### DIFF
--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -981,4 +981,15 @@ if (typeof(tests) !== "object") {
         indexes: [{"h": 1, "b": 1, "e.b": 1, "d": 1, "e.h": 1}],
         query: {"h": {$gt: 1}, "b": {$lt: 100}, "e.b": {$gt: 1}, "d": {$gt: 10}, "e.h": {$gt: 1}}
     });
+
+    // Select ~99% from two int indexed fields of a compound index with range predicates on both
+    // fields.
+    addTestCaseWithMultipleDatasetsAndIndexes({
+        names: ["RangeQuery_CompoundIndex_ComplexBounds_ThreeFields_Range_LS"],
+        cardinalities: [100000],
+        tags: ["indexed"],
+        docGenerator: smallDoc,
+        indexes: [{"a": 1, "b": 1}],
+        query: {"a": {$gt: 1}, "b": {$lt: 100000}}
+    });
 }());

--- a/testcases/simple_query.js
+++ b/testcases/simple_query.js
@@ -985,7 +985,7 @@ if (typeof(tests) !== "object") {
     // Select ~99% from two int indexed fields of a compound index with range predicates on both
     // fields.
     addTestCaseWithMultipleDatasetsAndIndexes({
-        names: ["RangeQuery_CompoundIndex_ComplexBounds_ThreeFields_Range_LS"],
+        names: ["RangeQuery_CompoundIndex_ComplexBounds_TwoIntFields_Range_LS"],
         cardinalities: [100000],
         tags: ["indexed"],
         docGenerator: smallDoc,


### PR DESCRIPTION
Thanks for submitting a PR to the Mongo-Perf repo. Please include the following fields (if relevant) prior to submitting your PR.

**Jira Ticket:** SERVER-83288

**Whats Changed:**
Add a new perf test case for compound index with two integer fields, the existing ones are with random doubles so that there isn't range scanning for the same first fields.

**Related PRs:**
https://github.com/10gen/mongo/pull/19125