### PR TITLE
SERVER-87587 Tag relevant "high value" cases for agg-query-comparison_read_commands suite

### DIFF
--- a/testcases/simple_in_queries.js
+++ b/testcases/simple_in_queries.js
@@ -118,7 +118,7 @@ if (typeof(tests) !== "object") {
      * includes every document, and two on larger collections of 10K and 1M documents with 
      * selective $in filters.
      */
-    function addInTestCases({name, largeInArray}) {
+    function addInTestCases({name, largeInArray, highValue = false}) {
         // Setup: Create a collection and insert a small number of documents with a random even
         // integer field x in the range [0, nLargeArrayElements * 2).
 
@@ -156,9 +156,10 @@ if (typeof(tests) !== "object") {
 
         // Similar test to above, but with an even larger collection. Only a small fraction (10%)
         // of the documents will actually match the filter.
+        var tags = highValue ? ["regression", "high_value"] : ["regression"];
         addQueryTestCase({
             name: name + "VeryBigCollection",
-            tags: ["regression"],
+            tags: tags,
             nDocs: 1e5,
             docs: function (i) {
                 return {x: 2 * Random.randInt(largeInArray.length * 10)};
@@ -203,6 +204,7 @@ if (typeof(tests) !== "object") {
     addInTestCases({
         name: "UnindexedVeryLargeInUnsortedMatching",
         largeInArray: veryLargeArrayRandom,
+        highValue: true
     });
 
     /**

--- a/testcases/simple_sort_queries.js
+++ b/testcases/simple_sort_queries.js
@@ -80,7 +80,7 @@ if (typeof(tests) !== "object") {
      */
     addQueryTestCase({
         name: "CoveredBlockingSort",
-        tags: ["core", "sort", "indexed"],
+        tags: ["core", "sort", "indexed", "high_value"],
         // TODO (SERVER-5722): We cannot create a views passthrough because benchRun doesn't support
         // sorting when running in read command mode.
         createViewsPassthrough: false,


### PR DESCRIPTION
Patch: https://spruce.mongodb.com/version/65f372922e0d6600072011ba/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

8 minutes for the new suite vs 4 hours previously :)