### PR TITLE
SERVER-90613 Zixuan Skunkworks 2024: Improve microbenchmark benchrun.py

### DIFF
--- a/benchrun.py
+++ b/benchrun.py
@@ -121,7 +121,7 @@ def print_summary(results_parsed):
     table =[]
     for result in results_parsed["results"]:
         name = result["name"]
-        variant = result["variant"]
+        variant = result.get("variant", "")
         for thread, values in result["results"].items():
             if isinstance(values, dict):
                 table.append([name, variant, thread, values['ops_per_sec'],

--- a/benchrun.py
+++ b/benchrun.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
-from argparse import ArgumentParser, RawTextHelpFormatter
-from subprocess import Popen, PIPE, check_call
-from tempfile import NamedTemporaryFile
-import datetime
-import sys
 import json
-import urllib.request, urllib.error, urllib.parse
 import os
-
+import sys
+from argparse import ArgumentParser, RawTextHelpFormatter
+from subprocess import PIPE, Popen, check_call
+from tempfile import NamedTemporaryFile
+from tabulate import tabulate
 
 
 class MongoShellCommandError(Exception):
@@ -120,17 +118,17 @@ def parse_arguments():
     return parser
 
 def print_summary(results_parsed):
-    print("name\tvariant\tthread_count\tops_per_sec(mean)\tops_per_sec(median)\tcount\tstdev")
+    table =[]
     for result in results_parsed["results"]:
         name = result["name"]
         variant = result["variant"]
         for thread, values in result["results"].items():
             if isinstance(values, dict):
-                print(
-                    f"{name}\t{variant}\t{thread}\t{values['ops_per_sec']:.4f}\t"
-                    f"{values['ops_per_sec_median']:.4f}\t{len(values['ops_per_sec_values'])}\t"
-                    f"{values['ops_per_sec_stdev']:.4f}"
-                )
+                table.append([name, variant, thread, values['ops_per_sec'],
+                              values['ops_per_sec_median'], len(values['ops_per_sec_values']),
+                              values['ops_per_sec_stdev']])
+    print(tabulate(table, headers=["name", "variant", "thread_count", "ops_per_sec(mean)",
+                                   "ops_per_sec(median)", "count", "stdev"], floatfmt=".4f"))
 
 def main():
     parser = parse_arguments()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-pymongo==2.7.2
-bottle==0.11.6
+pymongo==4.3.3
+bottle>=0.12.9
 argparse==1.2.1
 requests>=2.4.3
-psutil>=2.1.3
+psutil>=5.8.0
 ordereddict>=1.1
+tabulate>=0.9.0

--- a/util/utils.js
+++ b/util/utils.js
@@ -128,7 +128,7 @@ function CommandTracer(testName, options) {
         runningPre: "running pre() function",
         runningOps: "running benchRun ops",
         runningPost: "running post() function",
-        done: "done",
+        done: "done"
     };
 
     TestData = TestData || {};
@@ -471,6 +471,30 @@ function getMean(values) {
     return sum / values.length;
 }
 
+function getMedian(values) {
+    var sorted = Array.from(values).sort((a, b) => a - b);
+    var middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+    }
+
+    return sorted[middle];
+}
+
+function getStdev(values, mean) {
+    // Assigning (value - mean) ^ 2 to every array item
+    var arr = values.map((k) => {
+        return (k - mean) ** 2
+    });
+
+    // Calculating the sum of updated array
+    let sum = arr.reduce((acc, curr) => acc + curr, 0);
+
+    // Returning the standard deviation
+    return Math.sqrt(sum / arr.length)
+}
+
 function getNFieldNames(numFields) {
     var fieldNames = [];
     for (var i = 0; i < numFields; i++) {
@@ -518,14 +542,16 @@ function doCompare(test, compareTo) {
 
     if ( Array.isArray(compareTo) ) {
         for (var i = 0;i < compareTo.length; i++) {
-            if ( tags.indexOf(compareTo[i]) > -1 || test.name == compareTo[i]) {
+            const regx = new RegExp(compareTo[i] + "$");
+            if ( tags.indexOf(compareTo[i]) > -1 || test.name.match(regx)) {
                 return true;
             }
         }
         return false;
     }
     else {
-        if ( tags.indexOf(compareTo) > -1 || test.name == compareTo) {
+        const regx = new RegExp(compareTo + "$");
+        if ( tags.indexOf(compareTo) > -1 || test.name.match(regx)) {
             return true;
         }
     }
@@ -537,14 +563,16 @@ function doCompareExclude(test, compareTo) {
 
     if ( Array.isArray(compareTo) ) {
         for (var i = 0;i < compareTo.length; i++) {
-            if (!( tags.indexOf(compareTo[i]) > -1 || test.name == compareTo[i])) {
+            const regx = new RegExp(compareTo[i] + "$");
+            if (!( tags.indexOf(compareTo[i]) > -1 || test.name.match(regx))) {
                 return false;
             }
         }
         return true;
     }
     else {
-        if ( tags.indexOf(compareTo) > -1 || test.name == compareTo) {
+        const regx = new RegExp(compareTo + "$");
+        if ( tags.indexOf(compareTo) > -1 || test.name.match(regx)) {
             return false;
         }
     }
@@ -637,6 +665,89 @@ function doExecute(test, includeFilter, excludeFilter) {
     return true;
 }
 
+/**
+ * Run a single test with different threads config one or more times and measure the performance.
+ *
+ * @param test - the test to be ran
+ * @param threadCounts - array of threads to use
+ * @param multidb - multidb (number of dbs)
+ * @param multicoll - multicollection (number of collections)
+ * @param seconds - the time to run each performance test for
+ * @param trials - the number of trials to run
+ * @param shard - the number of shards the test is run for (defaults to 0)
+ * @param crudOptions - the crudOptions to be used with the test (see getDefaultCrudOptions() for defaults)
+ * @param variant - the current variant value
+ * @returns {{}} the results of a run set of tests
+ */
+function executeOneTest(test,
+                        threadCounts,
+                        multidb,
+                        multicoll,
+                        seconds,
+                        trials,
+                        shard,
+                        crudOptions,
+                        printArgs,
+                        shareDataset,
+                        variant,
+                        mongoeBenchOptions,
+                        username,
+                        password) {
+    print(test.name + (variant === "" ? "" : ", variant " + variant))
+    var threadResults = {};
+    threadResults['start'] = new Date();
+    for (var t = 0; t < threadCounts.length; t++) {
+        var threadCount = threadCounts[t];
+        var results = [];
+        var newResults = {};
+        for (var j = 0; j < trials; j++) {
+            try {
+                results[j] = runTest(test,
+                                     threadCount,
+                                     multidb,
+                                     multicoll,
+                                     seconds,
+                                     shard,
+                                     crudOptions,
+                                     printArgs,
+                                     shareDataset,
+                                     mongoeBenchOptions,
+                                     username,
+                                     password);
+            } catch (err) {
+                // Error handling to catch exceptions thrown in/by js for error
+                // Not all errors from the mongo shell are put up as js exceptions
+                print("Error running test " + test.name + ": " + err.message + ":\n" + err.stack);
+                errors.push({
+                    test: test,
+                    trial: j,
+                    threadCount: threadCount,
+                    multidb: multidb,
+                    multicoll: multicoll,
+                    shard: shard,
+                    crudOptions: crudOptions,
+                    username: username,
+                    password: password,
+                    error: {message: err.message, code: err.code}
+                })
+            }
+        }
+        var values = [];
+        var errors = [];
+        for (var j = 0; j < trials; j++) {
+            values[j] = results[j].ops_per_sec, errors[j] = results[j].error_count.toNumber()
+        }
+        // uncomment if one needs to save the trial values that comprise the mean
+        newResults.ops_per_sec_values = values;
+        newResults.error_values = errors;
+        newResults.ops_per_sec = getMean(values);
+        newResults.ops_per_sec_median = getMedian(values);
+        newResults.ops_per_sec_stdev = getStdev(values, newResults.ops_per_sec);
+        threadResults[threadCount] = newResults;
+    }
+    threadResults['end'] = new Date();
+    return threadResults;
+}
 
 /**
  * Run tests defined in a tests array (outside of the function)
@@ -652,108 +763,117 @@ function doExecute(test, includeFilter, excludeFilter) {
  * @param shard - the number of shards the test is run for (defaults to 0)
  * @param crudOptions - the crudOptions to be used with the test (see getDefaultCrudOptions() for defaults)
  * @param excludeTestbed - Exclude testbed information from results
+ * @param variantName - the variant name to be set in mongod
+ * @param variants - the variant values
  * @returns {{}} the results of a run set of tests
  */
-function runTests(
-    threadCounts, multidb, multicoll, seconds, trials, includeFilter, excludeFilter, shard,
-    crudOptions, excludeTestbed, printArgs, shareDataset, mongoeBenchOptions, username, password) {
+    function runTests(threadCounts,
+                      multidb,
+                      multicoll,
+                      seconds,
+                      trials,
+                      includeFilter,
+                      excludeFilter,
+                      shard,
+                      crudOptions,
+                      excludeTestbed,
+                      printArgs,
+                      shareDataset,
+                      variantName,
+                      variants,
+                      mongoeBenchOptions,
+                      username,
+                      password) {
+        if (typeof shard === "undefined")
+            shard = 0;
+        if (typeof crudOptions === "undefined")
+            crudOptions = getDefaultCrudOptions();
+        if (typeof includeFilter === "undefined")
+            includeFilter = "sanity";
+        if (typeof excludeTestbed === "undefined")
+            excludeTestbed = false;
+        if (typeof printArgs === "undefined")
+            printArgs = false;
 
-    if (typeof shard === "undefined") shard = 0;
-    if (typeof crudOptions === "undefined") crudOptions = getDefaultCrudOptions();
-    if (typeof includeFilter === "undefined") includeFilter = "sanity";
-    if (typeof excludeTestbed === "undefined") excludeTestbed = false;
-    if (typeof printArgs === "undefined") printArgs = false;
+        var testResults = {};
+        testResults.results = [];
 
-    var testResults = {};
-    testResults.results=[];
+        // Save basic testbed info if not running in evergreen
+        if (!excludeTestbed) {
+            var basicFields = {};
+            var bi = db.runCommand("buildInfo");
 
-    // Save basic testbed info if not running in evergreen
-    if (!excludeTestbed) {
-        var basicFields = {};
-        var bi = db.runCommand("buildInfo");
-
-        basicFields.commit = bi.gitVersion;
-        if (bi.sysInfo) {
-            basicFields.platform = bi.sysInfo.split(" ")[0];
+            basicFields.commit = bi.gitVersion;
+            if (bi.sysInfo) {
+                basicFields.platform = bi.sysInfo.split(" ")[0];
+            } else if (bi.buildEnvironment.target_os) {
+                basicFields.platform = bi.buildEnvironment.target_os;
+            } else {
+                basicFields.platform = "Unknown Platform";
+            }
+            basicFields.version = bi.version;
+            basicFields.crudOptions = crudOptions;  // Map
+            testResults['basicFields'] = basicFields;
         }
-        else if (bi.buildEnvironment.target_os) {
-            basicFields.platform = bi.buildEnvironment.target_os;
-        }
-        else {
-            basicFields.platform = "Unknown Platform";
-        }
-        basicFields.version = bi.version;
-        basicFields.crudOptions = crudOptions; // Map
-        testResults['basicFields'] = basicFields;
-    }
 
-    // Save storage engine information
-    testResults['storageEngine'] = db.runCommand("serverStatus").storageEngine.name;
+        // Save storage engine information
+        testResults['storageEngine'] = db.runCommand("serverStatus").storageEngine.name;
 
-    print("@@@START@@@");
-    testResults['start'] = new Date();
+        print("@@@START@@@");
+        testResults['start'] = new Date();
 
-    // Run all tests in the test file.
-    for (var i = 0; i < tests.length; i++) {
-        var test = tests[i];
-        var errors = [];
-        // Execute if it has a matching tag to the suite that was passed in
-        if ( doExecute(test, includeFilter, excludeFilter) ) {
-            print(test.name)
-            var threadResults = {};
-            threadResults['start'] = new Date();
-            for (var t = 0; t < threadCounts.length; t++) {
-                var threadCount = threadCounts[t];
-                var results = [];
-                var newResults = {};
-                for (var j = 0; j < trials; j++) {
-                    try {
-                        results[j] = runTest(
-                            test, threadCount, multidb, multicoll, seconds, shard, crudOptions,
-                            printArgs, shareDataset, mongoeBenchOptions, username, password);
-                    }
-                    catch(err) {
-                        // Error handling to catch exceptions thrown in/by js for error
-                        // Not all errors from the mongo shell are put up as js exceptions
-                        print("Error running test " + test.name + ": " + err.message + ":\n" + err.stack);
-                        errors.push({test: test,
-                                     trial: j,
-                                     threadCount: threadCount,
-                                     multidb: multidb,
-                                     multicoll: multicoll,
-                                     shard: shard,
-                                     crudOptions: crudOptions,
-                                     username: username,
-                                     password: password,
-                                     error: {message: err.message, code: err.code}})
+        // Run all tests in the test file.
+        for (var i = 0; i < tests.length; i++) {
+            var test = tests[i];
+            var errors = [];
+            // Execute if it has a matching tag to the suite that was passed in
+            if (doExecute(test, includeFilter, excludeFilter)) {
+                if (variantName === null) {
+                    var threadResults = executeOneTest(test,
+                                                       threadCounts,
+                                                       multidb,
+                                                       multicoll,
+                                                       seconds,
+                                                       trials,
+                                                       shard,
+                                                       crudOptions,
+                                                       printArgs,
+                                                       shareDataset,
+                                                       "",
+                                                       mongoeBenchOptions,
+                                                       username,
+                                                       password);
+                    testResults['results'].push({name: test.name, results: threadResults});
+                } else {
+                    for (var variant of variants) {
+                        db.adminCommand({setParameter: 1, [variantName]: NumberLong(variant)});
+                        var threadResults = executeOneTest(test,
+                                                           threadCounts,
+                                                           multidb,
+                                                           multicoll,
+                                                           seconds,
+                                                           trials,
+                                                           shard,
+                                                           crudOptions,
+                                                           printArgs,
+                                                           shareDataset,
+                                                           variant.toString(),
+                                                           mongoeBenchOptions,
+                                                           username,
+                                                           password);
+                        testResults['results'].push(
+                            {name: test.name, variant: variant, results: threadResults});
                     }
                 }
-                var values = [];
-                var errors = [];
-                for (var j = 0; j < trials; j++) {
-                    values[j] = results[j].ops_per_sec,
-                    errors[j] = results[j].error_count.toNumber()
-               }
-                // uncomment if one needs to save the trial values that comprise the mean
-                newResults.ops_per_sec_values = values;
-                newResults.error_values = errors;
-                newResults.ops_per_sec = getMean(values);
-                threadResults[threadCount] = newResults;
             }
-            threadResults['end'] = new Date();
-            testResults['results'].push({
-                name: test.name,
-                results: threadResults
-            });
         }
-    }
-    testResults['end'] = new Date();
-    testResults['errors'] =  errors;
-    // End delimiter for the useful output to be displayed.
-    print("@@@END@@@");
+        testResults['end'] = new Date();
+        testResults['errors'] = errors;
+        // End delimiter for the useful output to be displayed.
+        print("@@@END@@@");
 
-    return testResults;
-}
+        return testResults;
+    }
 
 /**
  * Run tests defined in a tests array (outside of the function)
@@ -768,14 +888,44 @@ function runTests(
  * @param shard - the number of shards the test is run for (defaults to 0)
  * @param crudOptions - the crudOptions to be used with the test (see getDefaultCrudOptions() for defaults)
  * @param excludeTestbed - Exclude testbed information from results
+ * @param variantName - the variant name to be set in mongod
+ * @param variants - the variant values
  * @returns {{}} the results of a run set of tests
  */
-function mongoPerfRunTests(
-    threadCounts, multidb, multicoll, seconds, trials, includeFilter, excludeFilter, shard,
-    crudOptions, excludeTestbed, printArgs, shareDataset, mongoeBenchOptions, username, password) {
-    testResults = runTests(
-        threadCounts, multidb, multicoll, seconds, trials, includeFilter, excludeFilter, shard,
-        crudOptions, excludeTestbed, printArgs, shareDataset, mongoeBenchOptions, username, password);
+function mongoPerfRunTests(threadCounts,
+                           multidb,
+                           multicoll,
+                           seconds,
+                           trials,
+                           includeFilter,
+                           excludeFilter,
+                           shard,
+                           crudOptions,
+                           excludeTestbed,
+                           printArgs,
+                           shareDataset,
+                           variantName,
+                           variants,
+                           mongoeBenchOptions,
+                           username,
+                           password) {
+    testResults = runTests(threadCounts,
+                           multidb,
+                           multicoll,
+                           seconds,
+                           trials,
+                           includeFilter,
+                           excludeFilter,
+                           shard,
+                           crudOptions,
+                           excludeTestbed,
+                           printArgs,
+                           shareDataset,
+                           variantName,
+                           variants,
+                           mongoeBenchOptions,
+                           username,
+                           password);
     print("@@@RESULTS_START@@@");
     print(JSON.stringify(testResults));
     print("@@@RESULTS_END@@@");

--- a/util/utils.js
+++ b/util/utils.js
@@ -914,7 +914,7 @@ function mongoPerfRunTests(threadCounts,
                            username,
                            password) {
     var testResults = "";
-    var oldValue = db.adminCommand({getParameter: 1, [variantName]: 1});
+    var oldValue = variantName === null ? null : db.adminCommand({getParameter: 1, [variantName]: 1});
     try {
         testResults = runTests(threadCounts,
                                multidb,
@@ -934,7 +934,9 @@ function mongoPerfRunTests(threadCounts,
                                username,
                                password);
     } finally {
-        db.adminCommand({setParameter: 1, [variantName]: NumberLong(oldValue[variantName])});
+        if (variantName !== null) {
+            db.adminCommand({setParameter: 1, [variantName]: NumberLong(oldValue[variantName])});
+        }
     }
     print("@@@RESULTS_START@@@");
     print(JSON.stringify(testResults));


### PR DESCRIPTION
1. Includes median and stdev for each test result
2. Allows users to provide a variant name and list of variant values and comparing the perf with different variants.
3. Allow users to use regex for filtering test names
4. Prints a summary at the end of test.

https://spruce.mongodb.com/version/664bdf7ab3280b0007d8c421/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

New `--tsvSummary` option output looks like
```
name                     variant    thread_count    ops_per_sec(mean)    ops_per_sec(median)    count    stdev
---------------------  ---------  --------------  -------------------  ---------------------  -------  -------
Aggregation.Group.All          0               1            1628.9812              1627.5134        3   3.7440
Aggregation.Group.All          1               1            1576.7357              1571.2285        3  17.9333
Aggregation.Group.All          2               1            1620.0208              1606.8993        3  20.7279
Aggregation.Group.All          4               1            1592.5159              1593.8476        3   5.9513
Aggregation.Group.All          8               1            1603.3958              1583.7102        3  29.6256